### PR TITLE
Fix aggregate plot theme toggle and remove legends

### DIFF
--- a/src/squiggy/plotting/aggregate.py
+++ b/src/squiggy/plotting/aggregate.py
@@ -110,6 +110,9 @@ def plot_aggregate(
         ],
     )
 
+    # Hide legend (title is descriptive enough)
+    p_signal.legend.visible = False
+
     # Track 2: Base pileup (IGV-style stacked bars)
     p_pileup = create_figure(
         title="Base Call Pileup",
@@ -203,6 +206,9 @@ def plot_aggregate(
     p_pileup.add_tools(hover_pileup)
     configure_legend(p_pileup)
 
+    # Hide legend (title is descriptive enough)
+    p_pileup.legend.visible = False
+
     # Add reference base labels above bars
     if reference_bases:
         # Extend y-axis range to accommodate labels
@@ -284,6 +290,9 @@ def plot_aggregate(
             ("Std Dev", "@std_q{0.1f}"),
         ],
     )
+
+    # Hide legend (title is descriptive enough)
+    p_quality.legend.visible = False
 
     # Link x-axes for synchronized zoom/pan
     p_pileup.x_range = p_signal.x_range

--- a/src/squiggy/viewer.py
+++ b/src/squiggy/viewer.py
@@ -698,11 +698,12 @@ class SquiggleViewer(QMainWindow):
         self.apply_theme()
 
         # Regenerate plot if one is displayed
-        if self.read_list.selectedItems():
-            await self._regenerate_plot_async()
-        elif self.plot_mode == PlotMode.AGGREGATE and self.selected_reference:
+        # Check aggregate mode first to avoid triggering read selection warning
+        if self.plot_mode == PlotMode.AGGREGATE and self.selected_reference:
             # Regenerate aggregate plot if in aggregate mode with selected reference
             await self.display_aggregate()
+        elif self.read_list.selectedItems():
+            await self._regenerate_plot_async()
         else:
             self.statusBar().showMessage(
                 f"Theme changed to {self.current_theme.value} mode"


### PR DESCRIPTION
## Summary
- Fix theme toggle in aggregate mode by prioritizing aggregate check before read selection check
- Remove unnecessary legends from all three aggregate panels (signal, pileup, quality)

## Changes
1. **viewer.py (lines 702-706)**: Reordered conditions in `toggle_theme()` to check `PlotMode.AGGREGATE` before checking `read_list.selectedItems()`. This prevents the warning message and allows theme changes to properly regenerate aggregate plots.

2. **aggregate.py**: Added `p.legend.visible = False` to all three panels:
   - Signal panel (line 114)
   - Pileup panel (line 210)  
   - Quality panel (line 295)

## Fixes
- Theme toggle in aggregate mode no longer shows "Aggregate mode displays multi-read pileup..." warning
- Theme changes now properly regenerate the aggregate plot
- Legends removed since panel titles are sufficiently descriptive

## Testing
- [x] Theme toggle works correctly in aggregate mode
- [x] Legends are hidden on all three panels
- [x] Panel titles remain visible and descriptive

🤖 Generated with [Claude Code](https://claude.com/claude-code)