### PR TITLE
Consolidate session state into single _squiggy_session object

### DIFF
--- a/squiggy/__init__.py
+++ b/squiggy/__init__.py
@@ -39,6 +39,8 @@ from .constants import (
 
 # I/O functions
 from .io import (
+    SquiggySession,
+    close_bam,
     close_pod5,
     get_bam_event_alignment_status,
     get_bam_modification_info,
@@ -371,6 +373,9 @@ __all__ = [
     "get_bam_event_alignment_status",
     "get_read_to_reference_mapping",
     "close_pod5",
+    "close_bam",
+    # Session management
+    "SquiggySession",
     # Data structures
     "AlignedRead",
     "BaseAnnotation",

--- a/src/state/extension-state.ts
+++ b/src/state/extension-state.ts
@@ -120,12 +120,12 @@ export class ExtensionState {
             try {
                 await this._positronClient.executeSilent(`
 import squiggy
+from squiggy.io import _squiggy_session
+# Close all resources via session
+_squiggy_session.close_all()
+# Also call module-level cleanup functions
 squiggy.close_pod5()
-# Clear global variables
-if '_squiggy_reader' in globals():
-    del _squiggy_reader
-if '_squiggy_read_ids' in globals():
-    del _squiggy_read_ids
+squiggy.close_bam()
 `);
             } catch (_error) {
                 // Ignore errors if kernel is not running

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,18 +9,20 @@ import pytest
 def clean_squiggy_state():
     """Automatically clean squiggy global state before and after each test."""
     # Clean state before test
-    from squiggy import close_pod5
-    from squiggy import io as squiggy_io
+    from squiggy import close_bam, close_pod5
+    from squiggy.io import _squiggy_session
 
     close_pod5()
-    # Also clear BAM path
-    squiggy_io._current_bam_path = None
+    close_bam()
+    # Also clean session
+    _squiggy_session.close_all()
 
     yield
 
     # Clean state after test
     close_pod5()
-    squiggy_io._current_bam_path = None
+    close_bam()
+    _squiggy_session.close_all()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Consolidates multiple kernel variables (`_squiggy_reader`, `_squiggy_read_ids`, `_squiggy_bam_info`, `_squiggy_ref_mapping`) into a single `_squiggy_session` object for cleaner Variables pane UX.

## Changes

### Python (Core Implementation)
- ✅ Added `SquiggySession` class with informative `__repr__()`
- ✅ Implemented `close_bam()` function for BAM cleanup
- ✅ Updated `load_pod5()` and `load_bam()` to populate session
- ✅ Maintained backward compatibility with legacy globals
- ✅ Exported `SquiggySession` and `close_bam()` in public API

### TypeScript (Kernel Communication)
- ✅ Updated `squiggy-runtime-api.ts` to use `_squiggy_session`
- ✅ Fixed BAM cleanup in `extension-state.ts`

### Testing
- ✅ Added 11 new session tests (31 total in `test_io.py`)
- ✅ Updated test fixtures to clean session state
- ✅ All 184 Python tests pass ✅
- ✅ All 80 TypeScript tests pass ✅
- ✅ Extension builds successfully ✅

### Documentation
- ✅ Updated `CLAUDE.md` with session-based state management examples

## Benefits

**Before:**
```
Variables pane shows:
- _squiggy_reader
- _squiggy_read_ids
- _squiggy_bam_info
- _squiggy_ref_mapping
```

**After:**
```
Variables pane shows:
- _squiggy_session
  <SquiggySession: POD5: data.pod5 (1,234 reads) | BAM: alignments.bam (1,234 reads)>
```

## Breaking Changes

⚠️ Users accessing internal variables directly will need to update:
- `_squiggy_reader` → `_squiggy_session.reader`
- `_squiggy_read_ids` → `_squiggy_session.read_ids`
- `_squiggy_bam_info` → `_squiggy_session.bam_info`
- `_squiggy_ref_mapping` → `_squiggy_session.ref_mapping`

**Note:** Legacy globals are still maintained for backward compatibility but are deprecated.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)