### PR TITLE
Convert launch.json to template-based system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ ENV/
 
 # IDEs
 .vscode/*
-!.vscode/launch.json
+!.vscode/launch.json.template
 !.vscode/tasks.json
 !.vscode/settings.json
 .idea/

--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -6,7 +6,7 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        "${workspaceFolder}/test-workspace",
+        "{{TEST_WORKSPACE_PATH}}",
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -82,6 +82,31 @@ pixi run build
 3. This launches a new **Extension Development Host** window with your extension loaded
 4. The extension recompiles automatically when you save changes (if you ran `npm run watch`)
 
+### Test Workspace Auto-Generation
+
+When you press F5, a test workspace is automatically created at `test-<branch>-<commit>/` (e.g., `test-main-db05aa3/`).
+
+**How it works**:
+
+1. The `prepare-extension` pre-launch task runs `scripts/setup-test-workspace.sh`
+2. This script:
+   - Creates `test-<branch>-<commit>/` directory (if it doesn't exist)
+   - Configures Python interpreter to use pixi environment
+   - Generates `.vscode/launch.json` from `.vscode/launch.json.template`
+3. The Extension Development Host opens with your test workspace
+
+**Key points**:
+
+- **`.vscode/launch.json.template`**: Committed template with `{{TEST_WORKSPACE_PATH}}` placeholder
+- **`.vscode/launch.json`**: Auto-generated, gitignored, points to current branch's test workspace
+- **Branch isolation**: Each branch gets its own test workspace (enables parallel testing sessions)
+- **Test data**: Place POD5/BAM files in `test-<branch>-<commit>/sample-data/`
+
+**Cleanup**:
+```bash
+pixi run clean  # Removes all test-*/ directories
+```
+
 ### Extension Commands
 
 Once the extension is running, open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and try:

--- a/scripts/setup-test-workspace.sh
+++ b/scripts/setup-test-workspace.sh
@@ -84,12 +84,15 @@ EOF
 
 echo "✓ Test workspace created successfully"
 
-# Update .vscode/launch.json to point to the new test workspace
+# Generate .vscode/launch.json from template
+LAUNCH_TEMPLATE="$PROJECT_ROOT/.vscode/launch.json.template"
 LAUNCH_JSON="$PROJECT_ROOT/.vscode/launch.json"
-if [ -f "$LAUNCH_JSON" ]; then
-    # Use sed to replace the test workspace path in launch.json
-    # Match pattern: "${workspaceFolder}/test-*" and replace with current directory name
-    sed -i.bak "s|\"\${workspaceFolder}/test-[^\"]*\"|\"\${workspaceFolder}/test-$BRANCH_NAME_CLEAN-$COMMIT_HASH\"|g" "$LAUNCH_JSON"
-    rm -f "$LAUNCH_JSON.bak"
-    echo "✓ Updated .vscode/launch.json to use $TEST_WORKSPACE"
+
+if [ -f "$LAUNCH_TEMPLATE" ]; then
+    # Replace placeholder with actual test workspace path
+    TEST_WORKSPACE_PATH="\${workspaceFolder}/test-$BRANCH_NAME_CLEAN-$COMMIT_HASH"
+    sed "s|{{TEST_WORKSPACE_PATH}}|$TEST_WORKSPACE_PATH|g" "$LAUNCH_TEMPLATE" > "$LAUNCH_JSON"
+    echo "✓ Generated .vscode/launch.json from template (test-$BRANCH_NAME_CLEAN-$COMMIT_HASH)"
+else
+    echo "⚠ Warning: .vscode/launch.json.template not found. Skipping launch.json generation."
 fi


### PR DESCRIPTION
## Summary

Fixes issue where branch-specific test workspace paths in `.vscode/launch.json` were being committed to version control, causing problems for other developers and making the file unsuitable for sharing.

## Changes

- **Create `.vscode/launch.json.template`**: Version-controlled template with `{{TEST_WORKSPACE_PATH}}` placeholder
- **Update `.gitignore`**: Track the template but ignore the generated `launch.json` file
- **Modify `setup-test-workspace.sh`**: Generate `launch.json` from template on each F5 press
- **Document in `DEVELOPER.md`**: Explain how the template system works

## Benefits

✅ Template is shared across all developers  
✅ Generated `launch.json` stays local-only (never committed)  
✅ Branch-specific isolation preserved (parallel sessions still work)  
✅ Visible directory names (`test-<branch>-<commit>/`)  
✅ Auto-updates on each F5 press with current branch/commit  

## Test Plan

- [x] Template generates valid `launch.json`
- [x] Extension launches correctly with generated workspace path
- [x] Branch-specific test workspaces still created properly
- [x] Documentation updated and clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)