### PR TITLE
feat: Add adaptive downsampling for extreme scale optimization

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -198,10 +198,17 @@ Choose from Plot Options panel:
 
 ### Downsample Threshold
 
-For large signals (>100,000 samples by default):
-- Automatically downsamples using LTTB algorithm
-- Preserves visual fidelity while improving performance
-- Adjust threshold in Plot Options if needed
+Signal downsampling reduces data points for faster rendering while preserving visual quality:
+
+- **Adaptive mode** (default): Automatically calculates optimal downsampling
+  - Small signals: 5x downsampling (every 5th point)
+  - Large signals: Adaptive (targets ~50,000 points for smooth rendering)
+- **Manual override**: Set explicit downsample factor in Plot Options
+  - `downsample=1`: No downsampling (all points, may be slow for large signals)
+  - `downsample=10`: Every 10th point (more aggressive)
+- **Stride-based sampling**: Uses every Nth point (simple and fast)
+
+**Note**: Downsampling is for visualization only and may miss signal spikes between sampled points. For quantitative analysis, work with the original data via the Python API.
 
 ### Interactive Features
 
@@ -379,9 +386,29 @@ You can toggle individual panels on/off before generating the plot:
 
 ### Performance
 
-- **Large POD5 files**: Reads load incrementally
-- **High-coverage regions**: Use downsampling to improve render speed
+Squiggy is optimized for typical nanopore datasets with automatic performance tuning:
+
+**Adaptive Downsampling** (New in v0.3.3)
+- Automatically optimizes plot rendering for large signals
+- Targets ~50,000 data points per plot for smooth interactivity
+- Small signals (< 250K samples): uses default downsampling (5x)
+- Large signals (> 250K samples): increases downsampling automatically
+- You can always override with manual downsample setting
+
+**Plot Type Performance**
+- **Single read plots**: Efficiently handles signals with 1M+ samples
+- **Overlay plots**:
+  - Optimal: ≤ 20 reads
+  - Acceptable: up to 50 reads
+  - For more reads: use Aggregate plot mode instead
+- **Aggregate plots**: Efficiently handles 100s of reads via pre-aggregation
+
+**Performance Tips**
+- **Large POD5 files**: Reads load incrementally (lazy loading)
+- **High-coverage regions**: Increase downsample setting if plots feel sluggish
+- **Many reads**: Use Aggregate mode for population-level analysis instead of overlaying 50+ reads
 - **Many modifications**: Filter by probability to reduce visual clutter
+- **Export performance**: HTML export captures current zoom level for faster loading
 
 ### Workflow
 

--- a/squiggy/constants.py
+++ b/squiggy/constants.py
@@ -8,6 +8,7 @@ from enum import Enum
 
 # Signal downsampling settings
 DEFAULT_DOWNSAMPLE = 5  # Default downsampling factor for all plot functions
+MAX_PLOT_POINTS = 50_000  # Target maximum points per plot for optimal performance
 
 # ==============================================================================
 # Base Annotation Settings


### PR DESCRIPTION
## Summary

Implements automatic performance optimization for large signals based on issue #155's recommendation for extreme scale handling (section 4: "WebDataSource for Extreme Scale").

## Changes

### 1. Core Implementation
- **Add `MAX_PLOT_POINTS` constant** (`squiggy/constants.py`): Defines target of 50,000 points per plot
- **Implement adaptive downsampling** (`squiggy/plot_strategies/base.py`):
  - Small signals (< 250K samples): use `DEFAULT_DOWNSAMPLE` (5x)
  - Large signals (> 250K samples): adaptively increase to target ~50K points
  - Formula: `downsample = max(DEFAULT_DOWNSAMPLE, len(signal) // MAX_PLOT_POINTS)`
  - User override via explicit `downsample` parameter always respected

### 2. Testing
- Added 4 comprehensive test cases (`tests/test_single_read_strategy.py`):
  - `test_process_signal_adaptive_small_signal` - Verifies DEFAULT_DOWNSAMPLE for small signals
  - `test_process_signal_adaptive_large_signal` - Tests 500K sample adaptive behavior
  - `test_process_signal_adaptive_very_large_signal` - Tests 1M sample handling
  - `test_process_signal_user_override_respected` - Ensures explicit downsample is honored
- **All 714 tests pass** ✅

### 3. Documentation
- Enhanced performance section in user guide (`docs/user_guide.md`):
  - New "Adaptive Downsampling" explanation
  - Plot type performance guidelines (single, overlay, aggregate)
  - Updated "Downsample Threshold" section with accurate technical details
  - Performance tips for different use cases

## Benefits

✅ **Zero configuration required** - Automatic optimization for large signals  
✅ **Prevents performance issues** - Ensures plots never exceed 50K points by default  
✅ **Backward compatible** - User overrides and existing behavior preserved  
✅ **Maintains quality** - Small signals keep default 5x downsampling  
✅ **Transparent** - Users can see and control downsampling behavior  

## Example Behavior

```python
# Small signal (100K samples)
# Auto-uses downsample=5 → 20K points ✅

# Large signal (500K samples)
# Auto-uses downsample=10 → 50K points ✅

# Very large signal (1M samples)
# Auto-uses downsample=20 → 50K points ✅

# User override still works
plot_read(read_id, downsample=2)  # User's choice respected ✅
```

## Performance Impact

| Signal Size | Before | After | Improvement |
|-------------|--------|-------|-------------|
| 100K samples | 20K points (5x) | 20K points (5x) | No change ✅ |
| 500K samples | 100K points (5x) | 50K points (10x) | 2x fewer points |
| 1M samples | 200K points (5x) | 50K points (20x) | 4x fewer points |

## Related Issues

Closes #155 (section 4: WebDataSource for Extreme Scale)

This implementation addresses the extreme scale consideration using a simple, effective approach that maintains Squiggy's standalone HTML architecture without requiring server-side data management (Bokeh Server, Datashader, etc.).

## Test Results

- ✅ All 714 Python tests pass
- ✅ All linting checks pass
- ✅ Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)