### PR TITLE
refactor: simplify kernel architecture to single dedicated kernel

### DIFF
--- a/src/commands/__tests__/plot-commands.test.ts
+++ b/src/commands/__tests__/plot-commands.test.ts
@@ -41,7 +41,7 @@ describe('Plot Commands', () => {
         mockState = {
             usePositron: true,
             squiggyAPI: mockAPI,
-            ensureBackgroundKernel: (jest.fn() as any).mockResolvedValue(mockAPI),
+            ensureKernel: (jest.fn() as any).mockResolvedValue(mockAPI),
             currentPod5File: null,
             currentBamFile: null,
             currentFastaFile: null,
@@ -88,12 +88,12 @@ describe('Plot Commands', () => {
         // Reset all vscode mocks
         jest.clearAllMocks();
 
-        // Re-setup ensureBackgroundKernel after clearAllMocks
+        // Re-setup ensureKernel after clearAllMocks
         mockAPI = {
             generatePlot: (jest.fn() as any).mockResolvedValue(undefined),
             generateAggregatePlot: (jest.fn() as any).mockResolvedValue(undefined),
         };
-        mockState.ensureBackgroundKernel = (jest.fn() as any).mockResolvedValue(mockAPI);
+        mockState.ensureKernel = (jest.fn() as any).mockResolvedValue(mockAPI);
         mockState.squiggyAPI = mockAPI;
     });
 

--- a/src/commands/__tests__/state-commands.test.ts
+++ b/src/commands/__tests__/state-commands.test.ts
@@ -43,7 +43,8 @@ describe('State Commands', () => {
         // Mock state with minimal required properties
         mockState = {
             squiggyAPI: mockAPI,
-            ensureBackgroundKernel: (jest.fn() as any).mockResolvedValue(mockAPI),
+            kernelManager: {}, // Non-null to pass initialization check
+            ensureKernel: (jest.fn() as any).mockResolvedValue(mockAPI),
             readsViewPane: {
                 setLoading: jest.fn(),
                 setReads: jest.fn(),
@@ -100,8 +101,8 @@ describe('State Commands', () => {
     });
 
     describe('squiggy.refreshReads', () => {
-        it('should show warning when squiggyAPI is not available', async () => {
-            mockState.squiggyAPI = null;
+        it('should show warning when kernel manager is not available', async () => {
+            mockState.kernelManager = null;
 
             registerCommands();
             const handler = commandHandlers.get('squiggy.refreshReads');
@@ -109,7 +110,7 @@ describe('State Commands', () => {
             await handler!();
 
             expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-                'Squiggy API not initialized'
+                'Squiggy kernel not initialized'
             );
         });
 

--- a/src/commands/state-commands.ts
+++ b/src/commands/state-commands.ts
@@ -45,8 +45,8 @@ export function registerStateCommands(
  * Re-fetches data from squiggy_kernel instead of using cached data
  */
 async function refreshReadsFromBackend(state: ExtensionState): Promise<void> {
-    if (!state.squiggyAPI) {
-        vscode.window.showWarningMessage('Squiggy API not initialized');
+    if (!state.kernelManager) {
+        vscode.window.showWarningMessage('Squiggy kernel not initialized');
         return;
     }
 
@@ -55,7 +55,7 @@ async function refreshReadsFromBackend(state: ExtensionState): Promise<void> {
         state.readsViewPane?.setLoading(true, 'Refreshing read list...');
 
         // Get background API
-        const api = await state.ensureBackgroundKernel();
+        const api = await state.ensureKernel();
 
         // Check if POD5 is loaded in Python session
         const hasPod5 = await api.client.getVariable('squiggy_kernel._reader is not None');
@@ -90,7 +90,7 @@ async function refreshReadsFromBackend(state: ExtensionState): Promise<void> {
  */
 async function refreshPOD5Only(state: ExtensionState): Promise<void> {
     // Get background API
-    const api = await state.ensureBackgroundKernel();
+    const api = await state.ensureKernel();
 
     // Get total read count
     const totalReads = await api.client.getVariable('len(squiggy_kernel._read_ids)');
@@ -114,7 +114,7 @@ async function refreshPOD5Only(state: ExtensionState): Promise<void> {
  */
 async function refreshWithBAM(state: ExtensionState): Promise<void> {
     // Get background API
-    const api = await state.ensureBackgroundKernel();
+    const api = await state.ensureKernel();
 
     // Get references from Python session
     const references = await api.getReferences();
@@ -142,7 +142,7 @@ async function refreshWithBAM(state: ExtensionState): Promise<void> {
 async function debugModificationsPanel(state: ExtensionState): Promise<void> {
     try {
         // Get background API
-        const api = await state.ensureBackgroundKernel();
+        const api = await state.ensureKernel();
 
         // Check if BAM is loaded in Python
         const hasBAM = await api.client.getVariable('squiggy_kernel._bam_path is not None');

--- a/src/services/__tests__/file-loading-service.test.ts
+++ b/src/services/__tests__/file-loading-service.test.ts
@@ -31,7 +31,7 @@ describe('FileLoadingService', () => {
 
         mockState = {
             squiggyAPI: mockAPI,
-            ensureBackgroundKernel: jest.fn().mockResolvedValue(mockAPI),
+            ensureKernel: jest.fn().mockResolvedValue(mockAPI),
         } as any;
 
         service = new FileLoadingService(mockState);
@@ -39,8 +39,8 @@ describe('FileLoadingService', () => {
         // Clear all mocks before each test
         jest.clearAllMocks();
 
-        // Re-setup ensureBackgroundKernel after clearAllMocks
-        mockState.ensureBackgroundKernel = jest.fn().mockResolvedValue(mockAPI);
+        // Re-setup ensureKernel after clearAllMocks
+        mockState.ensureKernel = jest.fn().mockResolvedValue(mockAPI);
     });
 
     describe('loadFile()', () => {
@@ -150,9 +150,7 @@ describe('FileLoadingService', () => {
         it('should return error when API is not initialized', async () => {
             const stateWithoutAPI = {
                 squiggyAPI: undefined,
-                ensureBackgroundKernel: jest
-                    .fn()
-                    .mockRejectedValue(new Error('API not initialized')),
+                ensureKernel: jest.fn().mockRejectedValue(new Error('API not initialized')),
             } as any;
             service = new FileLoadingService(stateWithoutAPI);
 
@@ -245,7 +243,7 @@ describe('FileLoadingService', () => {
             const apiWithoutFASTA = { ...mockAPI, loadFASTA: undefined } as any;
             const stateWithoutFASTA = {
                 squiggyAPI: apiWithoutFASTA,
-                ensureBackgroundKernel: jest.fn().mockResolvedValue(apiWithoutFASTA),
+                ensureKernel: jest.fn().mockResolvedValue(apiWithoutFASTA),
             } as any;
             service = new FileLoadingService(stateWithoutFASTA);
 

--- a/src/services/file-loading-service.ts
+++ b/src/services/file-loading-service.ts
@@ -118,9 +118,9 @@ export class FileLoadingService {
             `[loadSampleIntoRegistry] Starting - sample: '${sampleName}', pod5: ${pod5Path}, bam: ${bamPath || 'none'}`
         );
 
-        //Get background API (starts kernel if needed)
-        const api = await this.state.ensureBackgroundKernel();
-        logger.debug(`[loadSampleIntoRegistry] Background API ready, calling loadSample()...`);
+        // Get Squiggy kernel API (starts kernel if needed)
+        const api = await this.state.ensureKernel();
+        logger.debug(`[loadSampleIntoRegistry] Squiggy kernel API ready, calling loadSample()...`);
 
         try {
             // Load sample into registry (using dedicated kernel)
@@ -157,7 +157,7 @@ export class FileLoadingService {
     private async loadPOD5(filePath: string): Promise<POD5LoadResult> {
         try {
             // Get background API (starts kernel if needed)
-            const api = await this.state.ensureBackgroundKernel();
+            const api = await this.state.ensureKernel();
 
             // Load via background API (isolated from user's kernel)
             const result = await api.loadPOD5(filePath);
@@ -198,7 +198,7 @@ export class FileLoadingService {
     private async loadBAM(filePath: string): Promise<BAMLoadResult> {
         try {
             // Get background API (starts kernel if needed)
-            const api = await this.state.ensureBackgroundKernel();
+            const api = await this.state.ensureKernel();
 
             // Load via background API (isolated from user's kernel)
             const result = await api.loadBAM(filePath);
@@ -249,7 +249,7 @@ export class FileLoadingService {
     private async loadFASTA(filePath: string): Promise<FASTALoadResult> {
         try {
             // Get background API (starts kernel if needed)
-            const api = await this.state.ensureBackgroundKernel();
+            const api = await this.state.ensureKernel();
 
             // Load via background API (isolated from user's kernel)
             await api.loadFASTA(filePath);

--- a/src/state/__tests__/extension-state.test.ts
+++ b/src/state/__tests__/extension-state.test.ts
@@ -21,7 +21,8 @@ describe('ExtensionState', () => {
         });
 
         it('should have undefined backend references initially', () => {
-            expect(state.positronClient).toBeUndefined();
+            // Kernel manager and API are undefined until initializeBackends is called
+            expect(state.kernelManager).toBeUndefined();
             expect(state.squiggyAPI).toBeUndefined();
         });
 
@@ -119,8 +120,8 @@ describe('ExtensionState', () => {
         });
 
         it('should provide getter access to backend instances', () => {
-            // All backend instances start as undefined
-            expect(state.positronClient).toBeUndefined();
+            // All backend instances start as undefined until initializeBackends is called
+            expect(state.kernelManager).toBeUndefined();
             expect(state.squiggyAPI).toBeUndefined();
         });
 

--- a/src/types/squiggy-positron.d.ts
+++ b/src/types/squiggy-positron.d.ts
@@ -79,7 +79,8 @@ declare module 'positron' {
             allowIncomplete?: boolean,
             mode?: RuntimeCodeExecutionMode,
             errorBehavior?: RuntimeErrorBehavior,
-            observer?: RuntimeCodeExecutionObserver
+            observer?: RuntimeCodeExecutionObserver,
+            sessionId?: string
         ): Thenable<Record<string, any>>;
 
         export function getForegroundSession(): Thenable<LanguageRuntimeSession | undefined>;
@@ -125,6 +126,18 @@ declare module 'positron' {
          * Delete/shutdown a session
          */
         export function deleteSession(sessionId: string): Thenable<void>;
+
+        /**
+         * List all active sessions
+         */
+        export function getActiveSessions(): Thenable<BaseLanguageRuntimeSession[]>;
+
+        /**
+         * Get a specific session by its ID
+         */
+        export function getSession(
+            sessionId: string
+        ): Thenable<BaseLanguageRuntimeSession | undefined>;
 
         /**
          * Event that fires when the foreground session changes (including kernel restarts)

--- a/src/views/__tests__/squiggy-motif-panel.test.ts
+++ b/src/views/__tests__/squiggy-motif-panel.test.ts
@@ -21,7 +21,7 @@ describe('MotifSearchPanelProvider', () => {
         mockState = {
             currentFastaFile: null,
             squiggyAPI: null,
-            ensureBackgroundKernel: jest.fn(),
+            ensureKernel: jest.fn(),
         } as any;
 
         // Mock webview view
@@ -94,7 +94,7 @@ describe('MotifSearchPanelProvider', () => {
                 { chrom: 'chr1', position: 500, sequence: 'AGACT', strand: '+' },
             ]);
 
-            mockState.ensureBackgroundKernel.mockResolvedValue({
+            mockState.ensureKernel.mockResolvedValue({
                 searchMotif: mockSearchMotif,
             });
 
@@ -128,7 +128,7 @@ describe('MotifSearchPanelProvider', () => {
 
             const mockSearchMotif = (jest.fn() as any).mockResolvedValue([]);
 
-            mockState.ensureBackgroundKernel.mockResolvedValue({
+            mockState.ensureKernel.mockResolvedValue({
                 searchMotif: mockSearchMotif,
             });
 
@@ -152,7 +152,7 @@ describe('MotifSearchPanelProvider', () => {
                 new Error('Search failed')
             );
 
-            mockState.ensureBackgroundKernel.mockResolvedValue({
+            mockState.ensureKernel.mockResolvedValue({
                 searchMotif: mockSearchMotif,
             });
 
@@ -179,7 +179,7 @@ describe('MotifSearchPanelProvider', () => {
 
             const mockSearchMotif = (jest.fn() as any).mockRejectedValue('String error');
 
-            mockState.ensureBackgroundKernel.mockResolvedValue({
+            mockState.ensureKernel.mockResolvedValue({
                 searchMotif: mockSearchMotif,
             });
 
@@ -199,7 +199,7 @@ describe('MotifSearchPanelProvider', () => {
                 () => new Promise((resolve) => setTimeout(() => resolve([]), 10))
             );
 
-            mockState.ensureBackgroundKernel.mockResolvedValue({
+            mockState.ensureKernel.mockResolvedValue({
                 searchMotif: mockSearchMotif,
             });
 

--- a/src/views/squiggy-motif-panel.ts
+++ b/src/views/squiggy-motif-panel.ts
@@ -342,7 +342,7 @@ export class MotifSearchPanelProvider implements vscode.WebviewViewProvider {
         this.updateView();
 
         try {
-            const api = await this.state.ensureBackgroundKernel();
+            const api = await this.state.ensureKernel();
             const matches = await api.searchMotif(
                 this.state.currentFastaFile,
                 motif,


### PR DESCRIPTION
## Summary

- Remove dual-kernel architecture (foreground + background fallback)
- Rename `ensureBackgroundKernel()` to `ensureKernel()` throughout codebase
- Add session reconnection on window reload via workspace state persistence
- Use event-driven session restoration (`onDidChangeForegroundSession`) instead of polling
- Auto-start kernel on extension activation

## Details

This PR simplifies the kernel management by:

1. **Single kernel mode**: Instead of trying background kernel first and falling back to foreground, we now always use a dedicated "Squiggy Dedicated Kernel" console session.

2. **Session persistence**: The kernel session ID is saved to workspace state, allowing reconnection after window reload without creating duplicate kernels.

3. **Event-driven restoration**: On reload, we subscribe to `onDidChangeForegroundSession` to detect when Positron restores sessions, rather than polling.

4. **Auto-start**: The kernel starts automatically on extension activation.

## Test plan

- [x] Fresh start creates single kernel
- [x] Window reload reconnects to existing kernel (no duplicates)
- [x] All TypeScript tests pass
- [x] All Python tests pass
- [x] Linting and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)