### PR TITLE
feat: add reference header panel to aggregate plot

### DIFF
--- a/squiggy/plot_strategies/aggregate.py
+++ b/squiggy/plot_strategies/aggregate.py
@@ -165,6 +165,7 @@ class AggregatePlotStrategy(PlotStrategy):
         reference_name = data["reference_name"]
         num_reads = data["num_reads"]
         transformation_info = data.get("transformation_info", "")
+        sample_name = data.get("sample_name")
 
         # Extract options (transformation now happens in plot_aggregate() before this)
         normalization = options.get("normalization", NormalizationMethod.NONE)
@@ -185,6 +186,7 @@ class AggregatePlotStrategy(PlotStrategy):
         header = self._create_header_panel(
             reference_name=reference_name,
             num_reads=num_reads,
+            sample_name=sample_name,
         )
         panels.append([header])
         # Note: Don't add to all_figs - Div doesn't have x_range
@@ -318,19 +320,28 @@ class AggregatePlotStrategy(PlotStrategy):
         self,
         reference_name: str,
         num_reads: int,
+        sample_name: str | None = None,
     ):
-        """Create a compact header displaying reference information"""
+        """Create a compact header displaying sample and reference information"""
         text_color = self.theme_manager.get_color("title_text")
         bg_color = self.theme_manager.get_color("plot_bg")
 
+        # Build header text with optional sample name
+        if sample_name:
+            header_text = (
+                f"<b>{sample_name}</b> · {reference_name} ({num_reads:,} reads)"
+            )
+        else:
+            header_text = f"<b>{reference_name}</b> ({num_reads:,} reads)"
+
         header = Div(
-            text=f"<b>{reference_name}</b> ({num_reads:,} reads)",
+            text=header_text,
             styles={
                 "font-size": "14px",
                 "color": text_color,
                 "background-color": bg_color,
                 "padding": "8px 12px",
-                "text-align": "center",
+                "text-align": "left",
                 "width": "100%",
             },
             sizing_mode="stretch_width",

--- a/squiggy/plotting.py
+++ b/squiggy/plotting.py
@@ -686,6 +686,7 @@ def plot_aggregate(
         "reference_name": reference_name,
         "num_reads": num_reads,
         "transformation_info": transformation_info,  # Diagnostic info
+        "sample_name": sample_name,  # Optional sample name for multi-sample mode
     }
 
     options = {

--- a/tests/test_aggregate_strategy.py
+++ b/tests/test_aggregate_strategy.py
@@ -381,6 +381,23 @@ class TestAggregateTracks:
         assert "chr1:1000-1020" in header.text
         assert "15" in header.text  # num_reads
 
+    def test_header_panel_with_sample_name(self, sample_data):
+        """Test that header panel displays sample name when provided"""
+        from bokeh.models import Div
+
+        strategy = AggregatePlotStrategy(Theme.LIGHT)
+
+        # Add sample_name to data
+        sample_data["sample_name"] = "Sample_A"
+        _, grid = strategy.create_plot(sample_data, {})
+
+        # Header should contain sample name
+        header, _, _ = grid.children[0]
+        assert isinstance(header, Div)
+        assert "Sample_A" in header.text
+        assert "chr1:1000-1020" in header.text
+        assert "15" in header.text
+
     def test_signal_track_has_title(self, sample_data):
         """Test that signal track has appropriate title"""
         strategy = AggregatePlotStrategy(Theme.LIGHT)


### PR DESCRIPTION
## Summary

- Add a dedicated header panel at the top of aggregate plots displaying reference name and read count
- Header is always visible regardless of plot scroll position (previously this info was buried in the signal track title)
- Support optional sample name display for multi-sample mode
- Left-justify header text for better readability

## Changes

- **squiggy/plot_strategies/aggregate.py**: Add `_create_header_panel()` method using Bokeh `Div`, insert as first panel in gridplot
- **squiggy/plotting.py**: Pass `sample_name` to the strategy data dict
- **tests/test_aggregate_strategy.py**: Update tests for new 4-panel structure, add test for sample name display

## Header Format

- Without sample name: **chr1:1000-2000** (1,234 reads)
- With sample name: **Sample_A** · chr1:1000-2000 (1,234 reads)

## Test plan

- [x] All 38 aggregate strategy tests pass
- [ ] Manually verify header appears at top of aggregate plots
- [ ] Verify header displays correctly in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)