### PR TITLE
feat: add adapter trimming option to remove soft-clipped regions from signal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -294,7 +294,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -894,7 +893,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -918,7 +916,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2700,7 +2697,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2898,7 +2896,6 @@
       "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2910,7 +2907,6 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2950,8 +2946,7 @@
       "version": "1.106.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
       "integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3006,7 +3001,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -3940,7 +3934,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3987,7 +3980,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4358,7 +4350,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5169,7 +5160,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5479,7 +5471,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7036,7 +7027,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8112,7 +8102,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8479,6 +8468,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9407,7 +9397,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9561,6 +9550,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9576,6 +9566,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9745,7 +9736,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9758,7 +9748,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9772,7 +9761,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-window": {
       "version": "1.8.11",
@@ -11085,7 +11075,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11364,7 +11353,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11633,7 +11621,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11683,7 +11670,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/squiggy/plot_strategies/single_read.py
+++ b/squiggy/plot_strategies/single_read.py
@@ -151,6 +151,20 @@ class SingleReadPlotStrategy(PlotStrategy):
         min_mod_probability = options.get("min_mod_probability", 0.5)
         enabled_mod_types = options.get("enabled_mod_types", None)
         coordinate_space = options.get("coordinate_space", "signal")
+        trim_adapters = options.get("trim_adapters", False)
+
+        # Apply adapter trimming if requested (before normalization/downsampling)
+        if trim_adapters and aligned_read is not None:
+            signal, seq_to_sig_map, _ = self._apply_adapter_trimming(
+                signal, aligned_read, seq_to_sig_map
+            )
+            # Also trim the sequence if available
+            if sequence and aligned_read:
+                query_start = getattr(aligned_read, "query_start_offset", 0)
+                query_end = getattr(aligned_read, "query_end_offset", 0)
+                if query_start > 0 or query_end > 0:
+                    end_idx = len(sequence) - query_end if query_end > 0 else len(sequence)
+                    sequence = sequence[query_start:end_idx]
 
         # Process signal (normalize and downsample)
         signal, seq_to_sig_map = self._process_signal(

--- a/src/backend/squiggy-runtime-api.ts
+++ b/src/backend/squiggy-runtime-api.ts
@@ -264,7 +264,8 @@ squiggy.get_read_to_reference_mapping()
         downsample: number = 5,
         showSignalPoints: boolean = false,
         sampleName?: string,
-        coordinateSpace?: 'signal' | 'sequence'
+        coordinateSpace?: 'signal' | 'sequence',
+        trimAdapters: boolean = false
     ): Promise<void> {
         try {
             // Validate inputs
@@ -287,6 +288,10 @@ squiggy.get_read_to_reference_mapping()
                 ? `, coordinate_space='${coordinateSpace}'`
                 : '';
 
+            // Build trim adapters parameter
+            const trimAdaptersParam = `,
+    trim_adapters=${trimAdapters ? 'True' : 'False'}`;
+
             // Build the plot function call with proper multi-line formatting
             const plotCall =
                 readIds.length === 1
@@ -301,7 +306,7 @@ squiggy.get_read_to_reference_mapping()
     min_mod_probability=${minModProbability},
     enabled_mod_types=${enabledModTypesJson},
     downsample=${downsample},
-    show_signal_points=${showSignalPoints ? 'True' : 'False'}${sampleNameParam}${coordinateSpaceParam}
+    show_signal_points=${showSignalPoints ? 'True' : 'False'}${sampleNameParam}${coordinateSpaceParam}${trimAdaptersParam}
 )`
                     : `squiggy.plot_reads(
     ${readIdsJson},
@@ -314,7 +319,7 @@ squiggy.get_read_to_reference_mapping()
     min_mod_probability=${minModProbability},
     enabled_mod_types=${enabledModTypesJson},
     downsample=${downsample},
-    show_signal_points=${showSignalPoints ? 'True' : 'False'}${sampleNameParam}${coordinateSpaceParam}
+    show_signal_points=${showSignalPoints ? 'True' : 'False'}${sampleNameParam}${coordinateSpaceParam}${trimAdaptersParam}
 )`;
 
             const code = `
@@ -506,7 +511,8 @@ if '_squiggy_plot_error' in globals():
         sampleName?: string,
         minModFrequency: number = 0.2,
         minModifiedReads: number = 5,
-        rnaMode: boolean = false
+        rnaMode: boolean = false,
+        trimAdapters: boolean = false
     ): Promise<void> {
         try {
             // Validate inputs
@@ -591,7 +597,8 @@ squiggy.plot_aggregate(
     show_coverage=${showCoverage ? 'True' : 'False'},
     clip_x_to_alignment=${clipXAxisToAlignment ? 'True' : 'False'},
     transform_coordinates=${transformCoordinates ? 'True' : 'False'},
-    rna_mode=${rnaMode ? 'True' : 'False'}${sampleNameParam}
+    rna_mode=${rnaMode ? 'True' : 'False'},
+    trim_adapters=${trimAdapters ? 'True' : 'False'}${sampleNameParam}
 )
 `;
 

--- a/src/commands/plot-commands.ts
+++ b/src/commands/plot-commands.ts
@@ -384,7 +384,8 @@ async function plotReads(
                 options.downsample,
                 options.showSignalPoints,
                 state.selectedReadExplorerSample || undefined, // Pass current sample for multi-sample mode
-                coordinateSpace
+                coordinateSpace,
+                options.trimAdapters ?? false
             );
             logger.info('Plot generated successfully (dedicated kernel)');
         },
@@ -443,7 +444,9 @@ async function plotAggregate(referenceName: string, state: ExtensionState): Prom
                 true, // transformCoordinates
                 undefined, // Pass current sample for multi-sample mode
                 modFilters.minFrequency,
-                modFilters.minModifiedReads
+                modFilters.minModifiedReads,
+                false, // rnaMode
+                options.trimAdapters ?? false
             );
         },
         ErrorContext.PLOT_GENERATE,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -480,7 +480,8 @@ async function registerAllPanelsAndCommands(context: vscode.ExtensionContext): P
                         options.sampleNames[0],
                         modFilters.minFrequency,
                         modFilters.minModifiedReads,
-                        options.rnaMode
+                        options.rnaMode,
+                        options.trimAdapters ?? false
                     );
 
                     statusBarMessenger.show(`Aggregate: ${options.reference}`, 'graph');

--- a/src/state/__tests__/session-state-manager.test.ts
+++ b/src/state/__tests__/session-state-manager.test.ts
@@ -65,6 +65,7 @@ describe('SessionStateManager', () => {
                 scaleDwellTime: false,
                 downsample: 5,
                 showSignalPoints: false,
+                trimAdapters: false,
             },
         };
 

--- a/src/state/extension-state.ts
+++ b/src/state/extension-state.ts
@@ -763,6 +763,7 @@ squiggy.close_fasta()
                   scaleDwellTime: providerOptions.scaleDwellTime ?? false,
                   downsample: providerOptions.downsample ?? 5,
                   showSignalPoints: providerOptions.showSignalPoints ?? false,
+                  trimAdapters: providerOptions.trimAdapters ?? false,
               }
             : {
                   mode: 'SINGLE',
@@ -772,6 +773,7 @@ squiggy.close_fasta()
                   scaleDwellTime: false,
                   downsample: 5,
                   showSignalPoints: false,
+                  trimAdapters: false,
               };
 
         // Get modification filters if available

--- a/src/state/session-state-manager.ts
+++ b/src/state/session-state-manager.ts
@@ -213,6 +213,7 @@ export class SessionStateManager {
                 scaleDwellTime: false,
                 downsample: 5,
                 showSignalPoints: false,
+                trimAdapters: false,
             },
 
             // No modification filters for demo (yeast data doesn't have mods)

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -197,6 +197,7 @@ export interface GenerateAggregatePlotMessage extends BaseMessage {
     clipXAxisToAlignment: boolean;
     transformCoordinates: boolean;
     rnaMode: boolean;
+    trimAdapters?: boolean;
 }
 
 export interface GenerateMultiReadOverlayMessage extends BaseMessage {
@@ -268,6 +269,7 @@ export interface PlotOptions {
     showSignalPoints: boolean;
     clipXAxisToAlignment?: boolean;
     transformCoordinates?: boolean;
+    trimAdapters?: boolean; // Trim soft-clipped (adapter) regions from signals
 
     // Multi-Read Overlay/Stacked options
     maxReadsMulti?: number;

--- a/src/types/squiggy-session-types.ts
+++ b/src/types/squiggy-session-types.ts
@@ -15,6 +15,7 @@ export interface PlotOptionsState {
     scaleDwellTime: boolean;
     downsample: number;
     showSignalPoints: boolean;
+    trimAdapters: boolean;
 }
 
 /**

--- a/src/views/__tests__/squiggy-plot-options-panel.test.ts
+++ b/src/views/__tests__/squiggy-plot-options-panel.test.ts
@@ -187,28 +187,40 @@ describe('PlotOptionsViewProvider', () => {
 
             await messageHandler({
                 type: 'generateAggregatePlot',
+                sampleNames: ['sample1'],
                 reference: 'chr2',
                 maxReads: 150,
+                viewStyle: 'overlay',
                 normalization: 'MAD',
                 showModifications: true,
                 showPileup: true,
                 showDwellTime: false,
                 showSignal: true,
                 showQuality: true,
+                showCoverage: false,
                 clipXAxisToAlignment: true,
+                transformCoordinates: true,
+                rnaMode: false,
+                trimAdapters: false,
             });
 
             // Should fire event with plot parameters
             expect(aggregatePlotListener).toHaveBeenCalledWith({
+                sampleNames: ['sample1'],
                 reference: 'chr2',
                 maxReads: 150,
+                viewStyle: 'overlay',
                 normalization: 'MAD',
                 showModifications: true,
                 showPileup: true,
                 showDwellTime: false,
                 showSignal: true,
                 showQuality: true,
+                showCoverage: false,
                 clipXAxisToAlignment: true,
+                transformCoordinates: true,
+                rnaMode: false,
+                trimAdapters: false,
             });
         });
     });

--- a/src/views/components/squiggy-plot-options-core.tsx
+++ b/src/views/components/squiggy-plot-options-core.tsx
@@ -40,6 +40,7 @@ interface PlotOptionsState {
     showSignalPoints: boolean;
     clipXAxisToAlignment: boolean;
     transformCoordinates: boolean;
+    trimAdapters: boolean;
 
     // Multi-Read options (Overlay/Stacked)
     maxReadsMulti: number;
@@ -83,6 +84,7 @@ export const PlotOptionsCore: React.FC = () => {
         showSignalPoints: false,
         clipXAxisToAlignment: true,
         transformCoordinates: true,
+        trimAdapters: false,
         // Multi-Read
         maxReadsMulti: 50,
         // Aggregate defaults (now supports 1+ samples)
@@ -131,6 +133,7 @@ export const PlotOptionsCore: React.FC = () => {
                             message.options.clipXAxisToAlignment ?? prev.clipXAxisToAlignment,
                         transformCoordinates:
                             message.options.transformCoordinates ?? prev.transformCoordinates,
+                        trimAdapters: message.options.trimAdapters ?? prev.trimAdapters,
                         aggregateReference:
                             message.options.aggregateReference || prev.aggregateReference,
                         aggregateMaxReads:
@@ -319,6 +322,7 @@ export const PlotOptionsCore: React.FC = () => {
             clipXAxisToAlignment: options.clipXAxisToAlignment,
             transformCoordinates: options.transformCoordinates,
             rnaMode: options.rnaMode,
+            trimAdapters: options.trimAdapters,
         });
     };
 
@@ -997,6 +1001,37 @@ export const PlotOptionsCore: React.FC = () => {
                         >
                             Anchor position 1 to first reference base (uncheck to use genomic
                             coordinates)
+                        </div>
+
+                        {/* Trim Adapters */}
+                        <div className="plot-options-checkbox-row">
+                            <input
+                                type="checkbox"
+                                id="trimAdaptersAggregate"
+                                checked={options.trimAdapters}
+                                onChange={(e) =>
+                                    setOptions((prev) => ({
+                                        ...prev,
+                                        trimAdapters: e.target.checked,
+                                    }))
+                                }
+                                disabled={!options.hasBam}
+                            />
+                            <label
+                                htmlFor="trimAdaptersAggregate"
+                                className="plot-options-checkbox-label"
+                            >
+                                Trim adapters (soft-clipped regions)
+                            </label>
+                        </div>
+                        <div
+                            className="plot-options-description"
+                            style={{
+                                marginTop: '-6px',
+                                marginBottom: '10px',
+                            }}
+                        >
+                            Remove signal from soft-clipped adapter sequences before plotting
                         </div>
                     </div>
                 </>

--- a/src/views/squiggy-plot-options-panel.ts
+++ b/src/views/squiggy-plot-options-panel.ts
@@ -50,6 +50,7 @@ export class PlotOptionsViewProvider extends BaseWebviewProvider {
     private _showSignalPoints: boolean = false;
     private _clipXAxisToAlignment: boolean = true;
     private _transformCoordinates: boolean = true;
+    private _trimAdapters: boolean = false;
     private _hasPod5File: boolean = false;
     private _hasBamFile: boolean = false;
 
@@ -132,6 +133,7 @@ export class PlotOptionsViewProvider extends BaseWebviewProvider {
         clipXAxisToAlignment: boolean;
         transformCoordinates: boolean;
         rnaMode: boolean;
+        trimAdapters: boolean;
     }>();
     public readonly onDidRequestAggregatePlot = this._onDidRequestAggregatePlot.event;
 
@@ -205,6 +207,9 @@ export class PlotOptionsViewProvider extends BaseWebviewProvider {
             if (message.options.transformCoordinates !== undefined) {
                 this._transformCoordinates = message.options.transformCoordinates;
             }
+            if (message.options.trimAdapters !== undefined) {
+                this._trimAdapters = message.options.trimAdapters;
+            }
 
             // Update aggregate-specific options if present
             if (message.options.aggregateReference !== undefined) {
@@ -255,6 +260,7 @@ export class PlotOptionsViewProvider extends BaseWebviewProvider {
                 clipXAxisToAlignment: message.clipXAxisToAlignment,
                 transformCoordinates: message.transformCoordinates,
                 rnaMode: message.rnaMode,
+                trimAdapters: message.trimAdapters ?? false,
             });
         }
 
@@ -407,6 +413,7 @@ export class PlotOptionsViewProvider extends BaseWebviewProvider {
             showSignalPoints: this._showSignalPoints,
             clipXAxisToAlignment: this._clipXAxisToAlignment,
             transformCoordinates: this._transformCoordinates,
+            trimAdapters: this._trimAdapters,
             aggregateReference: this._aggregateReference,
             aggregateMaxReads: this._aggregateMaxReads,
             showModifications: this._showModifications,

--- a/tests/test_adapter_trimming.py
+++ b/tests/test_adapter_trimming.py
@@ -1,0 +1,325 @@
+"""Tests for adapter trimming functionality"""
+
+import numpy as np
+import pytest
+
+from squiggy.plotting import _apply_adapter_trimming_to_reads
+
+
+class TestApplyAdapterTrimmingToReads:
+    """Tests for _apply_adapter_trimming_to_reads function"""
+
+    def test_no_soft_clipping_unchanged(self):
+        """Reads without soft-clipping should be unchanged"""
+        read = {
+            "signal": np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            "sequence": "ACGT",
+            "move_table": np.array([1, 0, 1, 0, 1, 1], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 0,
+            "query_end_offset": 0,
+            "reference_start": 100,
+            "reference_end": 104,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 1
+        trimmed = result[0]
+        assert np.array_equal(trimmed["signal"], read["signal"])
+        assert trimmed["sequence"] == read["sequence"]
+        assert trimmed["reference_start"] == read["reference_start"]
+        assert trimmed["reference_end"] == read["reference_end"]
+
+    def test_soft_clip_at_start_only(self):
+        """Reads with soft-clipping at start should be trimmed correctly"""
+        # 8 bases total: 2 soft-clipped at start, 6 aligned
+        read = {
+            "signal": np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            "sequence": "NNACGTAC",  # NN are adapters, ACGTAC is aligned
+            "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 2,
+            "query_end_offset": 0,
+            "reference_start": 100,
+            "reference_end": 106,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 1
+        trimmed = result[0]
+        assert trimmed["sequence"] == "ACGTAC"
+        assert trimmed["query_start_offset"] == 0
+        assert trimmed["query_end_offset"] == 0
+        assert trimmed["reference_start"] == 102  # Increased by 2
+        assert trimmed["reference_end"] == 106  # Unchanged
+
+    def test_soft_clip_at_end_only(self):
+        """Reads with soft-clipping at end should be trimmed correctly"""
+        # 8 bases total: 6 aligned, 2 soft-clipped at end
+        read = {
+            "signal": np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            "sequence": "ACGTACNN",  # ACGTAC is aligned, NN are adapters
+            "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 0,
+            "query_end_offset": 2,
+            "reference_start": 100,
+            "reference_end": 106,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 1
+        trimmed = result[0]
+        assert trimmed["sequence"] == "ACGTAC"
+        assert trimmed["query_start_offset"] == 0
+        assert trimmed["query_end_offset"] == 0
+        assert trimmed["reference_start"] == 100  # Unchanged
+        assert trimmed["reference_end"] == 104  # Decreased by 2
+
+    def test_soft_clip_at_both_ends(self):
+        """Reads with soft-clipping at both ends should be trimmed correctly"""
+        # 10 bases total: 2 soft-clipped at start, 6 aligned, 2 soft-clipped at end
+        read = {
+            "signal": np.array(list(range(20))),
+            "sequence": "NNACGTACNN",  # NN...NN are adapters
+            "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 2,
+            "query_end_offset": 2,
+            "reference_start": 100,
+            "reference_end": 106,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 1
+        trimmed = result[0]
+        assert trimmed["sequence"] == "ACGTAC"
+        assert trimmed["query_start_offset"] == 0
+        assert trimmed["query_end_offset"] == 0
+        assert trimmed["reference_start"] == 102  # Increased by 2
+        assert trimmed["reference_end"] == 104  # Decreased by 2
+
+    def test_quality_scores_trimmed(self):
+        """Quality scores should be trimmed along with sequence"""
+        read = {
+            "signal": np.array(list(range(20))),
+            "sequence": "NNACGTACNN",
+            "quality_scores": np.array([10, 10, 30, 30, 30, 30, 30, 30, 10, 10]),
+            "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 2,
+            "query_end_offset": 2,
+            "reference_start": 100,
+            "reference_end": 106,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+        trimmed = result[0]
+
+        assert len(trimmed["quality_scores"]) == 6
+        assert np.array_equal(trimmed["quality_scores"], [30, 30, 30, 30, 30, 30])
+
+    def test_query_to_ref_adjusted(self):
+        """query_to_ref mapping should be adjusted for trimmed coordinates"""
+        read = {
+            "signal": np.array(list(range(20))),
+            "sequence": "NNACGTACNN",
+            "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 2,
+            "query_end_offset": 2,
+            "reference_start": 100,
+            "reference_end": 106,
+            # Original mapping: query 2->102, 3->103, 4->104, 5->105, 6->106, 7->107
+            "query_to_ref": {2: 102, 3: 103, 4: 104, 5: 105, 6: 106, 7: 107},
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+        trimmed = result[0]
+
+        # After trimming, query indices should be renumbered starting from 0
+        # New mapping: 0->102, 1->103, 2->104, 3->105, 4->106, 5->107
+        assert 0 in trimmed["query_to_ref"]
+        assert trimmed["query_to_ref"][0] == 102
+        assert trimmed["query_to_ref"][5] == 107
+        # Old keys should not exist
+        assert 2 not in trimmed["query_to_ref"] or trimmed["query_to_ref"].get(2) == 104
+
+    def test_move_table_base_count_matches_sequence(self):
+        """After trimming, move table should have same base count as sequence"""
+        # Create consistent data: 20 bases with move table matching sequence length
+        # 4 soft-clipped at start, 12 aligned, 4 soft-clipped at end
+        read = {
+            "signal": np.array(list(range(40))),  # 40 signal samples
+            "sequence": "NNNN" + "ACGT" * 3 + "NNNN",  # 4 + 12 + 4 = 20 bases
+            "move_table": np.array([1, 0] * 20, dtype=np.uint8),  # 20 bases (1,0 pattern)
+            "stride": 1,
+            "query_start_offset": 4,
+            "query_end_offset": 4,
+            "reference_start": 100,
+            "reference_end": 112,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 1
+        trimmed = result[0]
+        move_base_count = sum(trimmed["move_table"])
+        seq_len = len(trimmed["sequence"])
+        # After trimming, move table bases should match sequence length
+        assert move_base_count == seq_len, f"Move table bases ({move_base_count}) != sequence length ({seq_len})"
+        assert seq_len == 12  # 20 - 4 - 4 = 12 aligned bases
+
+    def test_empty_list_returns_empty(self):
+        """Empty input list should return empty output"""
+        result = _apply_adapter_trimming_to_reads([])
+        assert result == []
+
+    def test_multiple_reads_processed(self):
+        """Multiple reads should all be processed"""
+        reads = [
+            {
+                "signal": np.array([1, 2, 3, 4, 5, 6]),
+                "sequence": "ACGT",
+                "move_table": np.array([1, 0, 1, 0, 1, 1], dtype=np.uint8),
+                "stride": 1,
+                "query_start_offset": 0,
+                "query_end_offset": 0,
+                "reference_start": 100,
+                "reference_end": 104,
+            },
+            {
+                "signal": np.array([1, 2, 3, 4, 5, 6, 7, 8]),
+                "sequence": "NNACGT",  # 2 soft-clipped
+                "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),
+                "stride": 1,
+                "query_start_offset": 2,
+                "query_end_offset": 0,
+                "reference_start": 100,
+                "reference_end": 104,
+            },
+        ]
+
+        result = _apply_adapter_trimming_to_reads(reads)
+
+        assert len(result) == 2
+        # First read unchanged
+        assert result[0]["sequence"] == "ACGT"
+        # Second read trimmed
+        assert result[1]["sequence"] == "ACGT"
+        assert result[1]["reference_start"] == 102
+
+    def test_read_without_signal_skipped(self):
+        """Reads without signal should be skipped"""
+        read = {
+            "signal": None,
+            "sequence": "ACGT",
+            "move_table": np.array([1, 1, 1, 1], dtype=np.uint8),
+            "stride": 1,
+            "query_start_offset": 1,
+            "query_end_offset": 1,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 0
+
+    def test_signal_trimmed_correctly(self):
+        """Signal should be trimmed based on move table base positions"""
+        # Create a read where each base corresponds to 2 signal samples (stride=2)
+        # 4 bases: A(soft), C, G, T(soft) -> signal indices 0-1, 2-3, 4-5, 6-7
+        read = {
+            "signal": np.array([1, 1, 2, 2, 3, 3, 4, 4]),  # 8 samples
+            "sequence": "ACGT",
+            "move_table": np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8),  # 4 bases
+            "stride": 1,  # stride=1 means each move entry = 1 sample
+            "query_start_offset": 1,  # First base soft-clipped
+            "query_end_offset": 1,  # Last base soft-clipped
+            "reference_start": 100,
+            "reference_end": 102,
+        }
+
+        result = _apply_adapter_trimming_to_reads([read])
+
+        assert len(result) == 1
+        trimmed = result[0]
+        # Should have middle 2 bases worth of signal
+        assert trimmed["sequence"] == "CG"
+        # Signal should be trimmed to correspond to C and G bases
+        assert len(trimmed["signal"]) > 0
+
+
+class TestAdapterTrimmingIntegration:
+    """Integration tests for adapter trimming with real data"""
+
+    def test_trimming_with_real_data(self, sample_pod5_file, indexed_bam_file):
+        """Test adapter trimming with actual POD5/BAM data"""
+        from squiggy.utils.bam import extract_reads_for_reference
+
+        # Get reads
+        reads_data = extract_reads_for_reference(
+            pod5_file=str(sample_pod5_file),
+            bam_file=str(indexed_bam_file),
+            reference_name=None,  # Get all reads
+            max_reads=10,
+        )
+
+        if not reads_data:
+            pytest.skip("No reads with alignments found in test data")
+
+        # Check if any reads have soft-clipping
+        reads_with_clips = [
+            r
+            for r in reads_data
+            if r.get("query_start_offset", 0) > 0 or r.get("query_end_offset", 0) > 0
+        ]
+
+        if not reads_with_clips:
+            pytest.skip("No reads with soft-clipping in test data")
+
+        # Apply trimming
+        trimmed_reads = _apply_adapter_trimming_to_reads(reads_data)
+
+        # Verify all soft-clip offsets are now 0
+        for trimmed in trimmed_reads:
+            assert trimmed.get("query_start_offset", 0) == 0
+            assert trimmed.get("query_end_offset", 0) == 0
+
+    def test_trimming_preserves_aligned_region(self, sample_pod5_file, indexed_bam_file):
+        """Test that trimming preserves the aligned region correctly"""
+        from squiggy.utils.bam import extract_reads_for_reference
+
+        reads_data = extract_reads_for_reference(
+            pod5_file=str(sample_pod5_file),
+            bam_file=str(indexed_bam_file),
+            reference_name=None,
+            max_reads=5,
+        )
+
+        if not reads_data:
+            pytest.skip("No reads with alignments found in test data")
+
+        for original in reads_data:
+            soft_start = original.get("query_start_offset", 0)
+            soft_end = original.get("query_end_offset", 0)
+
+            if soft_start == 0 and soft_end == 0:
+                continue
+
+            trimmed_list = _apply_adapter_trimming_to_reads([original])
+            if not trimmed_list:
+                continue
+
+            trimmed = trimmed_list[0]
+
+            # Reference start should increase by soft_start
+            expected_ref_start = original.get("reference_start", 0) + soft_start
+            assert trimmed.get("reference_start") == expected_ref_start
+
+            # Reference end should decrease by soft_end
+            expected_ref_end = original.get("reference_end", 0) - soft_end
+            assert trimmed.get("reference_end") == expected_ref_end


### PR DESCRIPTION
## Summary

Add a new "Trim Adapters" checkbox in the Plot Options panel that removes soft-clipped (adapter) regions from signal data before plotting. This is useful for focusing on the aligned portion of reads without adapter noise.

### Changes

**Python Backend:**
- Add `trim_adapters` parameter to `plot_read()`, `plot_reads()`, `plot_aggregate()`
- Add `_apply_adapter_trimming_to_reads()` helper function in `squiggy/plotting.py` that:
  - Trims signal based on soft-clip base positions from move table
  - Trims sequence and quality scores
  - Adjusts `reference_start`/`reference_end` coordinates
  - Adjusts `query_to_ref` mapping for new indices
  - Ensures move table base count matches sequence length
- Add soft-clip fields (`query_start_offset`, `query_end_offset`) to `AlignedRead` dataclass

**TypeScript Frontend:**
- Add `trimAdapters` to `PlotOptionsState` interface
- Add checkbox UI in Plot Options panel (Aggregate section)
- Wire parameter through `SquiggyRuntimeAPI.generateAggregatePlot()`

**Tests:**
- Add `tests/test_adapter_trimming.py` with 13 comprehensive tests covering:
  - No soft-clipping (unchanged)
  - Soft-clip at start/end/both ends
  - Quality scores trimming
  - query_to_ref adjustment
  - Move table base count consistency
  - Edge cases

## Important Note

Adapter trimming removes the actual **adapter sequences** that are soft-clipped in the BAM alignment. The poly-A tail that may be visible in tRNA plots is part of the **reference sequence**, not adapter - it will remain visible after trimming because it's part of the aligned region.

## Test plan

- [x] All 735 Python tests pass
- [x] All 564 TypeScript tests pass
- [x] Build compiles successfully
- [ ] Manual testing in Positron with POD5/BAM data

🤖 Generated with [Claude Code](https://claude.com/claude-code)