### PR TITLE
refactor: code audit cleanup across Python, TypeScript, and docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,25 @@ Squiggy provides both a simple functional API and an object-oriented API for wor
 
 ## Quick Start
 
+### Object-Oriented API (Recommended)
+
+```python
+from squiggy.api import Pod5File, BamFile
+
+# Load files using OO API
+pod5 = Pod5File("data.pod5")
+bam = BamFile("alignments.bam")
+
+# Browse reads
+reads = pod5.reads()
+print(f"Found {len(reads)} reads")
+
+# Plot a single read
+reads[0].plot()
+```
+
+### Functional API (Legacy)
+
 ```python
 from squiggy import load_pod5, load_bam, plot_read, get_read_ids
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Squiggy is a Positron IDE extension for visualizing Oxford Nanopore sequencing d
 
 ## System Requirements
 
-- **Positron IDE**: Version 2024.09.0 or later
+- **Positron IDE**: Version 2025.6.0 or later
 - **Operating Systems**: macOS (Intel/Apple Silicon), Linux, Windows
 - **Python**: 3.12 or later
 - **Memory**: 4GB RAM minimum (8GB recommended for large POD5 files)
@@ -42,14 +42,15 @@ Or visit the [OpenVSX marketplace page](https://open-vsx.org/extension/rnabioco/
 
 ### First Time Setup
 
-After installing the extension, a **Setup** panel will appear in the sidebar if the Python package is not detected. The panel provides:
+When you first use Squiggy, it automatically:
 
-- Step-by-step instructions to create a virtual environment
-- Copy-paste commands for installation
-- Direct link to select your Python interpreter
-- Automatic verification of setup completion
+1. Creates a dedicated virtual environment at `~/.venvs/squiggy`
+2. Installs the bundled `squiggy` Python package using `uv`
+3. Configures a background kernel for extension operations
 
-No command-line experience needed—just follow the guided setup!
+**No manual Python package installation required!** The extension handles everything.
+
+> **Note:** The automatic setup requires `uv` to be installed. If `uv` is not found, you'll be prompted to install it.
 
 ### Alternative: Install from VSIX
 

--- a/docs/multi_sample_comparison.md
+++ b/docs/multi_sample_comparison.md
@@ -296,15 +296,15 @@ print(f"{len(unique_b)} reads only in B")
 
 ### Signal Distribution Comparison
 
-Compare statistical properties:
+Compare statistical properties using the `compare_samples` function:
 
 ```python
-from squiggy import compare_signal_distributions
+from squiggy import compare_samples
 
-dist = compare_signal_distributions(signal_a, signal_b)
-print(f"Mean A: {dist['mean_a']:.2f} pA")
-print(f"Mean B: {dist['mean_b']:.2f} pA")
-print(f"Difference: {dist['mean_a'] - dist['mean_b']:.2f} pA")
+comp = compare_samples(["sample_a", "sample_b"])
+print(f"Common reads: {len(comp['common_reads'])}")
+print(f"Unique to A: {len(comp['unique_to_a'])}")
+print(f"Unique to B: {len(comp['unique_to_b'])}")
 ```
 
 ### Batch Comparison Workflow

--- a/docs/quick_reference.md
+++ b/docs/quick_reference.md
@@ -163,7 +163,28 @@ Access via: `Preferences` → `Settings` → search "squiggy"
 
 ## Python API Cheat Sheet
 
-### Basic Operations
+### Object-Oriented API (Recommended)
+
+```python
+from squiggy.api import Pod5File, BamFile, FastaFile
+
+# Load files
+pod5 = Pod5File("data.pod5")
+bam = BamFile("alignments.bam")
+fasta = FastaFile("reference.fa")
+
+# Browse reads
+reads = pod5.reads()
+print(f"Found {len(reads)} reads")
+
+# Plot a read
+reads[0].plot(mode="EVENTALIGN", normalization="ZNORM")
+
+# Search motifs
+matches = fasta.search_motif("DRACH", region="chr1:1000-2000")
+```
+
+### Functional API (Legacy)
 
 ```python
 from squiggy import load_pod5, load_bam, load_fasta
@@ -354,7 +375,7 @@ wc -l file.fasta
 
 ### Extension Won't Load
 
-- [ ] Positron 2024.09.0 or later?
+- [ ] Positron 2025.6.0 or later?
 - [ ] Python 3.12+?
 - [ ] Virtual environment activated?
 - [ ] Reload extension: View → Extensions → Reload

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -578,7 +578,7 @@ For complete API documentation, see the **[API Reference](api.md)**.
 ## System Requirements
 
 **Software:**
-- **Positron IDE** 2024.09.0 or later
+- **Positron IDE** 2025.6.0 or later
 - **Python** 3.12 or later
 - **Operating Systems**: macOS (Intel/Apple Silicon), Linux, Windows
 

--- a/squiggy/alignment.py
+++ b/squiggy/alignment.py
@@ -1,10 +1,13 @@
 """Alignment handling for event-aligned squiggle visualization"""
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
 import pysam
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -62,9 +65,8 @@ def extract_alignment_from_bam(bam_path: Path, read_id: str) -> AlignedRead | No
             for alignment in bam.fetch(until_eof=True):
                 if alignment.query_name == read_id:
                     return _parse_alignment(alignment)
-    except Exception:
-        # Error reading BAM file - return None
-        pass
+    except (ValueError, KeyError, OSError) as e:
+        logger.debug("Failed to read BAM file %s for read %s: %s", bam_path, read_id, e)
 
     return None
 
@@ -148,7 +150,7 @@ def _parse_alignment(alignment) -> AlignedRead | None:
 
     # Extract stride (first element) and moves (remaining elements)
     # Stride represents the neural network downsampling factor
-    # Typical values: 5 for DNA models, 10-12 for RNA models
+    # See constants.DNA_STRIDE (5) and RNA_STRIDE_MIN/MAX (10-12)
     stride = int(move_table[0])
     moves = move_table[1:]
 
@@ -236,9 +238,10 @@ def _parse_alignment(alignment) -> AlignedRead | None:
         from .modifications import extract_modifications_from_alignment
 
         modifications = extract_modifications_from_alignment(alignment, bases)
-    except Exception:
-        # Modifications are optional, don't fail if extraction fails
-        pass
+    except (ImportError, ValueError, KeyError) as e:
+        logger.debug(
+            "Failed to extract modifications for read %s: %s", alignment.query_name, e
+        )
 
     # Extract primer/adapter regions from PT tag
     primer_regions = _parse_pt_tag(alignment)

--- a/squiggy/constants.py
+++ b/squiggy/constants.py
@@ -10,6 +10,11 @@ from enum import Enum
 DEFAULT_DOWNSAMPLE = 5  # Default downsampling factor for all plot functions
 MAX_PLOT_POINTS = 50_000  # Target maximum points per plot for optimal performance
 
+# Move table stride values (neural network downsampling factors)
+DNA_STRIDE = 5  # Typical stride for DNA basecalling models
+RNA_STRIDE_MIN = 10  # Minimum stride for RNA basecalling models
+RNA_STRIDE_MAX = 12  # Maximum stride for RNA basecalling models
+
 # ==============================================================================
 # Base Annotation Settings
 # ==============================================================================

--- a/squiggy/modifications.py
+++ b/squiggy/modifications.py
@@ -14,11 +14,14 @@ References:
 - modkit: https://github.com/nanoporetech/modkit
 """
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pysam
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -200,7 +203,9 @@ def detect_modification_provenance(bam_file: Path) -> dict[str, Any]:
                     result["unknown"] = False
                     break
 
-    except Exception:
-        pass
+    except (ValueError, KeyError, OSError) as e:
+        logger.debug(
+            "Failed to detect modification provenance from %s: %s", bam_file, e
+        )
 
     return result

--- a/squiggy/motif.py
+++ b/squiggy/motif.py
@@ -263,6 +263,11 @@ def search_motif(
     regex_pattern = iupac_to_regex(motif)
     regex = re.compile(regex_pattern, re.IGNORECASE)
 
+    # Pre-compile reverse complement regex once (doesn't change per chromosome)
+    rc_motif = reverse_complement(motif)
+    rc_regex_pattern = iupac_to_regex(rc_motif)
+    rc_regex = re.compile(rc_regex_pattern, re.IGNORECASE)
+
     # Parse region if provided
     target_chrom = None
     target_start = None
@@ -307,9 +312,6 @@ def search_motif(
             # Search reverse strand
             if strand in ("-", "both"):
                 rc_seq = reverse_complement(seq)
-                rc_motif = reverse_complement(motif)
-                rc_regex_pattern = iupac_to_regex(rc_motif)
-                rc_regex = re.compile(rc_regex_pattern, re.IGNORECASE)
 
                 for match in rc_regex.finditer(rc_seq):
                     # Convert position back to forward strand coordinates

--- a/squiggy/plot_strategies/eventalign.py
+++ b/squiggy/plot_strategies/eventalign.py
@@ -5,6 +5,8 @@ This module implements the Strategy Pattern for event-aligned nanopore reads
 with base annotations.
 """
 
+import logging
+
 import numpy as np
 from bokeh.embed import file_html
 from bokeh.models import ColumnDataSource, HoverTool
@@ -18,6 +20,8 @@ from ..constants import (
 )
 from ..rendering import BaseAnnotationRenderer, ReferenceTrackRenderer, ThemeManager
 from .base import PlotStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class EventAlignPlotStrategy(PlotStrategy):
@@ -282,8 +286,8 @@ class EventAlignPlotStrategy(PlotStrategy):
                 ref_fig.min_border_left = 5
                 ref_fig.min_border_right = 5
 
-            except Exception:
-                # If reference track creation fails, continue without it
+            except (ValueError, KeyError, IndexError) as e:
+                logger.debug("Reference track creation failed: %s", e)
                 ref_fig = None
 
         # Generate HTML

--- a/squiggy/plot_strategies/reference_overlay.py
+++ b/squiggy/plot_strategies/reference_overlay.py
@@ -7,6 +7,7 @@ represents genomic coordinates, allowing direct comparison of ionic current
 profiles across reads at the same reference location.
 """
 
+import logging
 from collections import Counter
 from dataclasses import dataclass
 from typing import Any
@@ -19,6 +20,8 @@ from bokeh.resources import CDN
 from ..constants import MULTI_READ_COLORS, NormalizationMethod, Theme
 from ..rendering import BaseAnnotationRenderer, ReferenceTrackRenderer, ThemeManager
 from .base import PlotStrategy
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -587,5 +590,6 @@ class ReferenceOverlayPlotStrategy(PlotStrategy):
             ref_fig.min_border_right = 5
 
             return ref_fig
-        except Exception:
+        except (ValueError, KeyError, IndexError) as e:
+            logger.debug("Reference track creation failed: %s", e)
             return None

--- a/squiggy/plot_strategies/signal_overlay_comparison.py
+++ b/squiggy/plot_strategies/signal_overlay_comparison.py
@@ -6,6 +6,7 @@ with each sample color-coded using the Okabe-Ito colorblind-friendly palette.
 Includes reference nucleotide sequence annotation.
 """
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -21,6 +22,8 @@ from ..normalization import normalize_signal
 from ..rendering.base_annotation_renderer import BaseAnnotationRenderer
 from ..rendering.theme_manager import ThemeManager
 from .base import PlotStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class SignalOverlayComparisonStrategy(PlotStrategy):
@@ -295,9 +298,8 @@ class SignalOverlayComparisonStrategy(PlotStrategy):
                     signal_min=signal_min,
                     signal_max=signal_max,
                 )
-            except Exception:
-                # Silently skip base annotation rendering if it fails
-                pass
+            except (ValueError, KeyError, IndexError) as e:
+                logger.debug("Base annotation rendering failed: %s", e)
 
         # Configure legend
         p.legend.click_policy = "hide"  # Interactive legend

--- a/squiggy/plotting.py
+++ b/squiggy/plotting.py
@@ -5,6 +5,8 @@ This module contains all the high-level plotting functions for generating
 Bokeh visualizations of nanopore signal data.
 """
 
+import logging
+
 import numpy as np
 
 from .constants import (
@@ -35,6 +37,8 @@ from .utils import (
     get_available_reads_for_reference,
     parse_plot_parameters,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def plot_read(
@@ -1251,8 +1255,8 @@ def plot_motif_aggregate_all(
                 all_aligned_reads.extend(reads_data)
                 num_matches_with_reads += 1
 
-        except Exception:
-            # Skip motif matches that fail (e.g., no reads, edge of chromosome)
+        except (ValueError, KeyError, OSError) as e:
+            logger.debug("Skipping motif match that failed: %s", e)
             continue
 
     if not all_aligned_reads:
@@ -1416,7 +1420,8 @@ def plot_delta_comparison(
                     reference_name=reference_name,
                 )
                 available_reads_per_sample.append(available)
-            except Exception:
+            except (ValueError, OSError) as e:
+                logger.debug("Failed to count reads for reference: %s", e)
                 available_reads_per_sample.append(100)  # Fallback
 
         # Use minimum available, capped at 100
@@ -1614,7 +1619,8 @@ def plot_signal_overlay_comparison(
                     reference_name=reference_name,
                 )
                 available_reads_per_sample.append(available)
-            except Exception:
+            except (ValueError, OSError) as e:
+                logger.debug("Failed to count reads for reference: %s", e)
                 available_reads_per_sample.append(100)  # Fallback
 
         # Use minimum available, capped at 100
@@ -1684,9 +1690,8 @@ def plot_signal_overlay_comparison(
                         reference_name, min_pos, max_pos + 1
                     )
                     fasta.close()
-                except Exception:
-                    # FASTA fetch failed, will fall back to BAM
-                    pass
+                except (ValueError, KeyError, OSError) as e:
+                    logger.debug("FASTA fetch failed, falling back to BAM: %s", e)
 
             # Fallback to BAM reconstruction if FASTA unavailable
             if not reference_sequence:
@@ -1701,9 +1706,8 @@ def plot_signal_overlay_comparison(
                         reference_sequence = (
                             reads[0].get("reference_sequence", "") or ""
                         )
-                except Exception:
-                    # If we can't get reference sequence, continue without it
-                    pass
+                except (ValueError, KeyError, OSError) as e:
+                    logger.debug("BAM reference extraction failed: %s", e)
 
     # Prepare data for plot strategy
     data = {
@@ -1850,7 +1854,8 @@ def plot_aggregate_comparison(
                     reference_name=reference_name,
                 )
                 available_reads_per_sample.append(available)
-            except Exception:
+            except (ValueError, OSError) as e:
+                logger.debug("Failed to count reads for reference: %s", e)
                 available_reads_per_sample.append(100)  # Fallback
 
         # Use minimum available, capped at 100

--- a/squiggy/utils/bam.py
+++ b/squiggy/utils/bam.py
@@ -1,5 +1,6 @@
 """BAM file utilities for Squiggy"""
 
+import logging
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -10,6 +11,8 @@ import pod5
 import pysam
 
 from .paths import writable_working_directory
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -65,7 +68,7 @@ class ModelProvenance:
         )
 
 
-def validate_bam_reads_in_pod5(bam_file, pod5_file):
+def validate_bam_reads_in_pod5(bam_file: str | Path, pod5_file: str | Path) -> dict:
     """Validate that all reads in BAM file exist in POD5 file
 
     This is a sanity check to ensure the BAM file corresponds to the POD5 file.
@@ -141,7 +144,7 @@ def get_basecall_data(
 
                     # Extract stride (first element) and moves (remaining elements)
                     # Stride represents the neural network downsampling factor
-                    # Typical values: 5 for DNA models, 10-12 for RNA models
+                    # See constants.DNA_STRIDE (5) and RNA_STRIDE_MIN/MAX (10-12)
                     stride = int(move_table[0])
                     moves = move_table[1:]
 
@@ -158,8 +161,8 @@ def get_basecall_data(
 
         bam.close()
 
-    except Exception:
-        pass
+    except (ValueError, KeyError, OSError) as e:
+        logger.debug("Failed to extract basecall data for read %s: %s", read_id, e)
 
     return None, None
 
@@ -223,7 +226,7 @@ def parse_region(region_str: str) -> tuple[str | None, int | None, int | None]:
         return region_str.strip(), None, None
 
 
-def index_bam_file(bam_file):
+def index_bam_file(bam_file: str | Path) -> None:
     """Generate BAM index file (.bai)
 
     Creates a .bai index file for the given BAM file using pysam.
@@ -281,9 +284,8 @@ def get_bam_references(bam_file: Path) -> list[dict]:
                         # Count mapped reads for this reference
                         count = bam.count(ref_name)
                         ref_info["read_count"] = count
-                    except Exception:
-                        # If counting fails, leave as None
-                        pass
+                    except (ValueError, OSError) as e:
+                        logger.debug("Failed to count reads for %s: %s", ref_name, e)
 
                 # Only include references that have reads
                 # If read_count is None (no index), include it
@@ -297,7 +299,9 @@ def get_bam_references(bam_file: Path) -> list[dict]:
     return references
 
 
-def get_read_to_reference_mapping(bam_file, pod5_read_ids):
+def get_read_to_reference_mapping(
+    bam_file: str | Path, pod5_read_ids: set | list
+) -> dict[str, str]:
     """Get mapping of read IDs to their reference sequences from BAM file
 
     Args:
@@ -335,8 +339,8 @@ def get_read_to_reference_mapping(bam_file, pod5_read_ids):
                 ref_name = bam.get_reference_name(read.reference_id)
                 read_to_ref[read_id] = ref_name
 
-    except Exception:
-        # If there's an error reading BAM, return empty mapping
+    except (ValueError, OSError) as e:
+        logger.debug("Failed to read BAM for reference mapping: %s", e)
         return {}
 
     return read_to_ref
@@ -433,7 +437,9 @@ def reverse_complement(seq: str) -> str:
     return "".join(complement.get(base, base) for base in reversed(seq))
 
 
-def get_reference_sequence_for_read(bam_file, read_id):
+def get_reference_sequence_for_read(
+    bam_file: str | Path, read_id: str
+) -> tuple[str | None, int | None, object | None]:
     """
     Extract the reference sequence for a given aligned read.
 
@@ -543,9 +549,10 @@ def get_reference_sequence_from_fasta(
             reference_sequence = fasta.fetch(reference_name, start, end)
             fasta.close()
             return reference_sequence
-        except Exception:
-            # FASTA fetch failed, will try BAM fallback
-            pass
+        except (ValueError, KeyError, OSError) as e:
+            logger.debug(
+                "FASTA fetch failed for %s:%d-%d: %s", reference_name, start, end, e
+            )
 
     # Fallback to BAM reconstruction if FASTA unavailable
     if not reference_sequence and bam_file and read_id:
@@ -558,14 +565,13 @@ def get_reference_sequence_from_fasta(
                 region_start = max(0, start - ref_start)
                 region_end = min(len(ref_seq), end - ref_start)
                 reference_sequence = ref_seq[region_start:region_end]
-        except Exception:
-            # BAM fallback failed, return empty string
-            pass
+        except (ValueError, KeyError, OSError) as e:
+            logger.debug("BAM fallback failed for read %s: %s", read_id, e)
 
     return reference_sequence
 
 
-def get_available_reads_for_reference(bam_file, reference_name):
+def get_available_reads_for_reference(bam_file: str | Path, reference_name: str) -> int:
     """Count total reads available for a reference in a BAM file
 
     Uses BAM index for O(log n) lookup instead of O(n) full scan.
@@ -667,9 +673,12 @@ def extract_reads_for_reference(
                     if aligned_read:
                         modifications = aligned_read.modifications
                         primer_regions = aligned_read.primer_regions
-                except Exception:
-                    # Modifications/primers are optional, don't fail if extraction fails
-                    pass
+                except (ImportError, ValueError, KeyError) as e:
+                    logger.debug(
+                        "Failed to extract modifications for read %s: %s",
+                        read.query_name,
+                        e,
+                    )
 
                 # Calculate soft-clipped bases at the start and end of the read
                 # This tells us how many bases in the raw signal to skip
@@ -813,9 +822,8 @@ def extract_model_provenance(bam_file: str) -> ModelProvenance:
                     if "DS" in pg:
                         provenance.flow_cell_kit = pg["DS"]
 
-    except Exception:
-        # Return partial provenance if there's an error
-        pass
+    except (ValueError, KeyError, OSError) as e:
+        logger.debug("Failed to extract model provenance: %s", e)
 
     return provenance
 
@@ -949,9 +957,12 @@ def extract_alignments_for_reference(
                     aligned_read = _parse_alignment(read)
                     if aligned_read:
                         modifications = aligned_read.modifications
-                except Exception:
-                    # Modifications are optional, don't fail if extraction fails
-                    pass
+                except (ImportError, ValueError, KeyError) as e:
+                    logger.debug(
+                        "Failed to extract modifications for read %s: %s",
+                        read.query_name,
+                        e,
+                    )
 
                 # Build query_pos -> ref_pos mapping from aligned pairs
                 aligned_pairs = {}

--- a/squiggy/utils/paths.py
+++ b/squiggy/utils/paths.py
@@ -1,5 +1,6 @@
 """Path and file location utilities for Squiggy"""
 
+import logging
 import os
 import platform
 import shutil
@@ -7,6 +8,8 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -86,8 +89,8 @@ def get_icon_path():
             path = Path(str(icon_path))
             if path.exists():
                 return path
-    except Exception:
-        pass
+    except (ImportError, TypeError, FileNotFoundError, OSError) as e:
+        logger.debug("Resource lookup failed: %s", e)
 
     # 3. Development location (relative to package)
     package_dir = Path(__file__).parent.parent
@@ -126,8 +129,8 @@ def get_logo_path():
             path = Path(str(logo_path))
             if path.exists():
                 return path
-    except Exception:
-        pass
+    except (ImportError, TypeError, FileNotFoundError, OSError) as e:
+        logger.debug("Resource lookup failed: %s", e)
 
     # 3. Development location
     package_dir = Path(__file__).parent.parent
@@ -311,8 +314,8 @@ def get_sample_bam_path():
                 try:
                     with resources.as_file(sample_bai_path) as f:
                         shutil.copy(f, temp_bai)
-                except Exception:
-                    pass  # BAI file optional
+                except (FileNotFoundError, OSError) as e:
+                    logger.debug("BAI copy failed (optional): %s", e)
             return temp_bam
 
         # If we got a source path, check if it's in a read-only location
@@ -377,5 +380,6 @@ def get_sample_bam_path():
 
         return None  # BAM file is optional
 
-    except Exception:
+    except (ImportError, FileNotFoundError, OSError) as e:
+        logger.debug("BAM file lookup failed (optional): %s", e)
         return None  # BAM file is optional

--- a/squiggy/utils/plotting.py
+++ b/squiggy/utils/plotting.py
@@ -25,7 +25,7 @@ def _route_to_plots_pane(fig) -> None:
         from bokeh.io import show
 
         show(fig)  # Positron intercepts this and routes to Plots pane
-    except Exception:
+    except (ImportError, RuntimeError):
         # Silently fail if bokeh.io not available or not in Positron
         pass
 

--- a/squiggy/utils/statistics.py
+++ b/squiggy/utils/statistics.py
@@ -1,8 +1,79 @@
 """Aggregate statistics utilities for Squiggy"""
 
+import logging
+
 import numpy as np
 
 from .signal import get_aligned_move_indices_from_read, iter_aligned_bases
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_reference_bases(
+    positions: list,
+    reference_name: str | None,
+    reads_data: list[dict],
+    fasta_file=None,
+    bam_file=None,
+) -> dict[int, str]:
+    """Extract reference bases for given positions using FASTA-first, BAM-fallback pattern.
+
+    Args:
+        positions: Sorted list of reference positions to look up.
+        reference_name: Name of reference sequence.
+        reads_data: List of read dicts (used for BAM fallback).
+        fasta_file: Path to FASTA reference file (preferred source).
+        bam_file: Path to BAM file (fallback source via MD tag reconstruction).
+
+    Returns:
+        Dict mapping position -> reference base character.
+    """
+    import pysam
+
+    from .bam import get_reference_sequence_for_read
+
+    if not reference_name or not reads_data or not positions:
+        return {}
+
+    reference_bases: dict[int, str] = {}
+
+    # Try FASTA first (most accurate)
+    if fasta_file:
+        try:
+            fasta = pysam.FastaFile(str(fasta_file))
+            min_pos = int(min(positions))
+            max_pos = int(max(positions))
+            ref_seq = fasta.fetch(reference_name, min_pos, max_pos + 1)
+            for pos in positions:
+                idx = int(pos) - min_pos
+                if 0 <= idx < len(ref_seq):
+                    reference_bases[pos] = ref_seq[idx].upper()
+            fasta.close()
+            if reference_bases:
+                return reference_bases
+        except (ValueError, KeyError, OSError) as e:
+            logger.debug("FASTA reference fetch failed for %s: %s", reference_name, e)
+
+    # Fall back to BAM file (uses MD tag or query sequence)
+    if bam_file and not reference_bases:
+        try:
+            for read in reads_data:
+                ref_seq, ref_start, _aligned_read = get_reference_sequence_for_read(
+                    bam_file, read["read_id"]
+                )
+                if ref_seq and ref_start is not None:
+                    for pos in positions:
+                        if pos in reference_bases:
+                            continue
+                        idx = pos - ref_start
+                        if 0 <= idx < len(ref_seq):
+                            reference_bases[pos] = ref_seq[idx].upper()
+                if len(reference_bases) >= len(positions):
+                    break
+        except (ValueError, KeyError, OSError) as e:
+            logger.debug("BAM reference fallback failed for %s: %s", reference_name, e)
+
+    return reference_bases
 
 
 def calculate_modification_statistics(
@@ -353,10 +424,6 @@ def calculate_base_pileup(
                      e.g., {pos: {'A': 10, 'C': 2, 'G': 5, 'T': 8}}
             - reference_bases: Dict mapping position to reference base (from FASTA or BAM)
     """
-    import pysam
-
-    from .bam import get_reference_sequence_for_read
-
     position_bases = {}
 
     for read in reads_data:
@@ -383,64 +450,12 @@ def calculate_base_pileup(
         "counts": {pos: position_bases[pos] for pos in positions},
     }
 
-    # Extract reference bases from FASTA (preferred) or BAM
-    if reference_name and reads_data and positions:
-        reference_bases = {}
-
-        # Try FASTA first (most accurate)
-        if fasta_file:
-            try:
-                fasta = pysam.FastaFile(str(fasta_file))
-                # Get the range of positions we need
-                min_pos = int(min(positions))
-                max_pos = int(max(positions))
-
-                # Fetch reference sequence for the region
-                ref_seq = fasta.fetch(reference_name, min_pos, max_pos + 1)
-
-                # Map each position to its reference base
-                for pos in positions:
-                    idx = int(pos) - min_pos
-                    if 0 <= idx < len(ref_seq):
-                        reference_bases[pos] = ref_seq[idx].upper()
-
-                fasta.close()
-
-                if reference_bases:
-                    result["reference_bases"] = reference_bases
-                    return result
-            except Exception:
-                # FASTA failed, fall back to BAM
-                pass
-
-        # Fall back to BAM file (uses MD tag or query sequence)
-        # Iterate through all reads to build complete reference coverage
-        if bam_file and not reference_bases:
-            try:
-                for read in reads_data:
-                    ref_seq, ref_start, aligned_read = get_reference_sequence_for_read(
-                        bam_file, read["read_id"]
-                    )
-
-                    if ref_seq and ref_start is not None:
-                        # Add reference bases from this read's alignment
-                        for pos in positions:
-                            if pos in reference_bases:
-                                continue  # Already have this position
-                            # Calculate index in reference sequence
-                            idx = pos - ref_start
-                            if 0 <= idx < len(ref_seq):
-                                reference_bases[pos] = ref_seq[idx].upper()
-
-                    # Stop early if we've covered all positions
-                    if len(reference_bases) >= len(positions):
-                        break
-
-                if reference_bases:
-                    result["reference_bases"] = reference_bases
-            except Exception:
-                # If we can't get reference sequence, just skip it
-                pass
+    # Extract reference bases using shared FASTA-first, BAM-fallback pattern
+    reference_bases = _extract_reference_bases(
+        positions, reference_name, reads_data, fasta_file=fasta_file, bam_file=bam_file
+    )
+    if reference_bases:
+        result["reference_bases"] = reference_bases
 
     return result
 
@@ -542,10 +557,6 @@ def calculate_base_pileup_from_alignments(
                      e.g., {pos: {'A': 10, 'C': 2, 'G': 5, 'T': 8}}
             - reference_bases: Dict mapping position to reference base (from FASTA or BAM)
     """
-    import pysam
-
-    from .bam import get_reference_sequence_for_read
-
     position_bases = {}
 
     for read in reads_data:
@@ -572,64 +583,12 @@ def calculate_base_pileup_from_alignments(
         "counts": {pos: position_bases[pos] for pos in positions},
     }
 
-    # Extract reference bases from FASTA (preferred) or BAM
-    if reference_name and reads_data and positions:
-        reference_bases = {}
-
-        # Try FASTA first (most accurate)
-        if fasta_file:
-            try:
-                fasta = pysam.FastaFile(str(fasta_file))
-                # Get the range of positions we need
-                min_pos = int(min(positions))
-                max_pos = int(max(positions))
-
-                # Fetch reference sequence for the region
-                ref_seq = fasta.fetch(reference_name, min_pos, max_pos + 1)
-
-                # Map each position to its reference base
-                for pos in positions:
-                    idx = int(pos) - min_pos
-                    if 0 <= idx < len(ref_seq):
-                        reference_bases[pos] = ref_seq[idx].upper()
-
-                fasta.close()
-
-                if reference_bases:
-                    result["reference_bases"] = reference_bases
-                    return result
-            except Exception:
-                # FASTA failed, fall back to BAM
-                pass
-
-        # Fall back to BAM file (uses MD tag or query sequence)
-        # Iterate through all reads to build complete reference coverage
-        if bam_file and not reference_bases:
-            try:
-                for read in reads_data:
-                    ref_seq, ref_start, aligned_read = get_reference_sequence_for_read(
-                        bam_file, read["read_id"]
-                    )
-
-                    if ref_seq and ref_start is not None:
-                        # Add reference bases from this read's alignment
-                        for pos in positions:
-                            if pos in reference_bases:
-                                continue  # Already have this position
-                            # Calculate index in reference sequence
-                            idx = pos - ref_start
-                            if 0 <= idx < len(ref_seq):
-                                reference_bases[pos] = ref_seq[idx].upper()
-
-                    # Stop early if we've covered all positions
-                    if len(reference_bases) >= len(positions):
-                        break
-
-                if reference_bases:
-                    result["reference_bases"] = reference_bases
-            except Exception:
-                # If we can't get reference sequence, just skip it
-                pass
+    # Extract reference bases using shared FASTA-first, BAM-fallback pattern
+    reference_bases = _extract_reference_bases(
+        positions, reference_name, reads_data, fasta_file=fasta_file, bam_file=bam_file
+    )
+    if reference_bases:
+        result["reference_bases"] = reference_bases
 
     return result
 

--- a/src/backend/squiggy-kernel-manager.ts
+++ b/src/backend/squiggy-kernel-manager.ts
@@ -676,7 +676,7 @@ assert hasattr(squiggy, 'plot_read'), "squiggy.plot_read not found"
             case positron.RuntimeState.Offline:
                 this.setState(SquiggyKernelState.Error);
                 logger.error(`Dedicated kernel exited unexpectedly (state: ${state})`);
-                // TODO: Implement auto-restart logic
+                // Auto-restart not implemented: users can restart via squiggy.restartBackgroundKernel command
                 break;
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -549,6 +549,12 @@ async function registerAllPanelsAndCommands(context: vscode.ExtensionContext): P
                             if (plotOptionsProvider) {
                                 plotOptionsProvider.updateReferences(uniqueRefs);
                             }
+                        })
+                        .catch((error) => {
+                            logger.error(
+                                '[extension.ts] Failed to fetch references from samples:',
+                                error
+                            );
                         });
                 }
             }

--- a/src/views/components/squiggy-files-core.tsx
+++ b/src/views/components/squiggy-files-core.tsx
@@ -19,8 +19,6 @@ import { vscode } from './vscode-api';
 import './squiggy-files-core.css';
 
 export const FilesCore: React.FC = () => {
-    console.log('FilesCore component mounted');
-
     // State
     const [state, setState] = React.useState<FilesViewState>({
         files: [],
@@ -30,10 +28,7 @@ export const FilesCore: React.FC = () => {
 
     // Handle messages from extension
     React.useEffect(() => {
-        console.log('FilesCore: Setting up message listener');
-
         const messageHandler = (event: MessageEvent) => {
-            console.log('FilesCore: Received message:', event.data);
             const message = event.data;
 
             switch (message.type) {
@@ -46,14 +41,12 @@ export const FilesCore: React.FC = () => {
         window.addEventListener('message', messageHandler);
 
         // Notify extension that webview is ready
-        console.log('FilesCore: Sending ready message');
         vscode.postMessage({ type: 'ready' });
 
         return () => window.removeEventListener('message', messageHandler);
     }, []);
 
     const handleUpdateFiles = (files: FileItem[]) => {
-        console.log('FilesCore: Received updateFiles with', files.length, 'files:', files);
         setState((prev) => ({
             ...prev,
             files: sortFiles(files, prev.sortColumn, prev.sortDirection),
@@ -81,9 +74,7 @@ export const FilesCore: React.FC = () => {
 
     const handleOpenPOD5 = () => {
         // New workflow: open file picker for POD5/BAM files
-        console.log('[FilesCore] handleOpenPOD5 clicked, sending addFiles message');
         vscode.postMessage({ type: 'addFiles' });
-        console.log('[FilesCore] addFiles message sent');
     };
 
     const handleOpenBAM = () => {

--- a/src/views/components/squiggy-modifications-core.tsx
+++ b/src/views/components/squiggy-modifications-core.tsx
@@ -98,10 +98,8 @@ export const ModificationsCore: React.FC = () => {
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             const message = event.data;
-            console.log('ModificationsCore received message:', message);
             switch (message.type) {
                 case 'updateModInfo':
-                    console.log('Updating mod info:', message);
                     setState({
                         hasModifications: message.hasModifications,
                         modificationTypes: message.modificationTypes,
@@ -113,7 +111,6 @@ export const ModificationsCore: React.FC = () => {
                     });
                     break;
                 case 'clearMods':
-                    console.log('Clearing mods');
                     setState({
                         hasModifications: false,
                         modificationTypes: [],
@@ -125,13 +122,12 @@ export const ModificationsCore: React.FC = () => {
                     });
                     break;
                 default:
-                    console.log('Unknown message type:', message.type);
+                    break;
             }
         };
 
         window.addEventListener('message', handleMessage);
         // Request initial state
-        console.log('ModificationsCore sending ready message');
         vscode.postMessage({ type: 'ready' });
 
         return () => window.removeEventListener('message', handleMessage);

--- a/src/views/components/squiggy-plot-options-core.tsx
+++ b/src/views/components/squiggy-plot-options-core.tsx
@@ -126,7 +126,6 @@ export const PlotOptionsCore: React.FC = () => {
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             const message = event.data;
-            console.log('[PlotOptions React] Received message:', message.type, message);
             switch (message.type) {
                 case 'updatePlotOptions':
                     setOptions((prev) => ({
@@ -160,14 +159,12 @@ export const PlotOptionsCore: React.FC = () => {
                     }));
                     break;
                 case 'updatePod5Status':
-                    console.log('[PlotOptions React] Updating hasPod5:', message.hasPod5);
                     setOptions((prev) => ({
                         ...prev,
                         hasPod5: message.hasPod5,
                     }));
                     break;
                 case 'updateBamStatus':
-                    console.log('[PlotOptions React] Updating hasBam:', message.hasBam);
                     setOptions((prev) => ({
                         ...prev,
                         hasBam: message.hasBam,
@@ -180,7 +177,6 @@ export const PlotOptionsCore: React.FC = () => {
                     }
                     break;
                 case 'updateFastaStatus':
-                    console.log('[PlotOptions React] Updating hasFasta:', message.hasFasta);
                     setOptions((prev) => ({
                         ...prev,
                         hasFasta: message.hasFasta,
@@ -195,11 +191,6 @@ export const PlotOptionsCore: React.FC = () => {
                     }));
                     break;
                 case 'updateLoadedSamples':
-                    console.log(
-                        '[PlotOptions React] Updating loadedSamples:',
-                        message.samples.length,
-                        'samples'
-                    );
                     setOptions((prev) => {
                         // Don't auto-select samples here - visualization selection is managed
                         // by the Sample Manager (eye icons) and synced via updateSelectedSamples message
@@ -230,10 +221,6 @@ export const PlotOptionsCore: React.FC = () => {
                     });
                     break;
                 case 'updateSelectedSamples':
-                    console.log(
-                        '[PlotOptions React] Updating selectedSamples from extension:',
-                        message.selectedSamples
-                    );
                     setOptions((prev) => {
                         // Recompute hasEvents/hasMods/hasPrimers based on new selection
                         const selectedSampleData = prev.loadedSamples.filter((s) =>
@@ -321,7 +308,6 @@ export const PlotOptionsCore: React.FC = () => {
     // Generate handlers for each plot type
     const handleGenerateAggregate = () => {
         // Unified handler: works for 1+ samples
-        console.log('[PlotOptions] Generating aggregate with samples:', options.selectedSamples);
         // Send effective values - if hasEvents is false, signal/dwell are forced off
         // This triggers plot_pileup() instead of plot_aggregate() for BAMs without mv tags
         const effectiveShowDwellTime = options.showDwellTime && options.hasEvents;

--- a/src/views/components/squiggy-reads-core.tsx
+++ b/src/views/components/squiggy-reads-core.tsx
@@ -66,12 +66,6 @@ export const ReadsCore: React.FC = () => {
 
             switch (message.type) {
                 case 'setAvailableSamples':
-                    console.log(
-                        '[ReadsCore] Received setAvailableSamples:',
-                        message.samples,
-                        'selected:',
-                        message.selectedSample
-                    );
                     setAvailableSamples(message.samples);
                     setSelectedSample(message.selectedSample);
                     break;

--- a/src/views/components/squiggy-samples-core.tsx
+++ b/src/views/components/squiggy-samples-core.tsx
@@ -56,11 +56,8 @@ export const SamplesCore: React.FC = () => {
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             const message = event.data;
-            console.log('SamplesCore received message:', message);
-
             switch (message.type) {
                 case 'updateSamples': {
-                    console.log('Updating samples:', message.samples);
                     setState((prev) => {
                         const samples = (message as any).samples as SampleItem[];
                         const newColors = new Map(prev.sampleColors);
@@ -82,9 +79,6 @@ export const SamplesCore: React.FC = () => {
                                     );
                                     if (matchingNewSample) {
                                         // Migrate the color to the new sample name
-                                        console.log(
-                                            `[SamplesCore] Migrating color for renamed sample: ${oldName} → ${matchingNewSample.name}`
-                                        );
                                         newColors.delete(oldName);
                                         newColors.set(matchingNewSample.name, oldColor);
                                     }
@@ -124,10 +118,6 @@ export const SamplesCore: React.FC = () => {
 
                         // Sync auto-selected samples with extension state (Issue #121)
                         if (newlySelectedSamples.length > 0) {
-                            console.log(
-                                '[SamplesCore] Auto-selecting samples in extension:',
-                                newlySelectedSamples
-                            );
                             setTimeout(() => {
                                 newlySelectedSamples.forEach((name) => {
                                     vscode.postMessage({
@@ -149,7 +139,6 @@ export const SamplesCore: React.FC = () => {
                 }
 
                 case 'clearSamples':
-                    console.log('Clearing samples');
                     setState({
                         samples: [],
                         sessionFastaPath: null,
@@ -162,7 +151,6 @@ export const SamplesCore: React.FC = () => {
                     break;
 
                 case 'updateSessionFasta':
-                    console.log('Updating session FASTA:', message.fastaPath);
                     setState((prev) => ({
                         ...prev,
                         sessionFastaPath: message.fastaPath,
@@ -170,10 +158,6 @@ export const SamplesCore: React.FC = () => {
                     break;
 
                 case 'updateVisualizationSelection':
-                    console.log(
-                        '[SamplesCore] Updating visualization selection from extension:',
-                        message.selectedSamples
-                    );
                     setState((prev) => ({
                         ...prev,
                         selectedSamplesForVisualization: new Set(message.selectedSamples),
@@ -181,20 +165,18 @@ export const SamplesCore: React.FC = () => {
                     break;
 
                 default:
-                    console.log('Unknown message type:', message.type);
+                    break;
             }
         };
 
         window.addEventListener('message', handleMessage);
         // Request initial state
-        console.log('SamplesCore sending ready message');
         vscode.postMessage({ type: 'ready' });
 
         return () => window.removeEventListener('message', handleMessage);
     }, []);
 
     const handleUnloadSample = (sampleName: string) => {
-        console.log('Requesting unload of sample:', sampleName);
         vscode.postMessage({
             type: 'unloadSample',
             sampleName,
@@ -225,7 +207,6 @@ export const SamplesCore: React.FC = () => {
     };
 
     const _handleLoadSamplesClick = () => {
-        console.log('🎯 DEBUG: Load Samples button clicked');
         vscode.postMessage({
             type: 'requestLoadSamples',
         });

--- a/src/views/squiggy-session-panel.ts
+++ b/src/views/squiggy-session-panel.ts
@@ -66,18 +66,22 @@ export class SessionPanelProvider extends BaseWebviewProvider {
         const hasSamples = Object.keys(currentState.samples).length > 0;
 
         // Check if there's a saved session
-        SessionStateManager.loadSession(this.context).then((savedSession) => {
-            const hasSavedSession = savedSession !== null;
+        SessionStateManager.loadSession(this.context)
+            .then((savedSession) => {
+                const hasSavedSession = savedSession !== null;
 
-            const message: UpdateSessionMessage = {
-                type: 'updateSession',
-                hasSamples,
-                hasSavedSession,
-                sampleCount: Object.keys(currentState.samples).length,
-                sampleNames: Object.keys(currentState.samples),
-            };
+                const message: UpdateSessionMessage = {
+                    type: 'updateSession',
+                    hasSamples,
+                    hasSavedSession,
+                    sampleCount: Object.keys(currentState.samples).length,
+                    sampleNames: Object.keys(currentState.samples),
+                };
 
-            this.postMessage(message);
-        });
+                this.postMessage(message);
+            })
+            .catch(() => {
+                // Session load failure is non-critical; panel will show default state
+            });
     }
 }


### PR DESCRIPTION
## Summary

- **Python**: Extract duplicated reference sequence logic into shared helper, replace ~25 bare `except Exception: pass` with specific types + logging, add type hints to `utils/bam.py`, add stride constants, fix regex recompilation in motif search
- **TypeScript**: Remove ~29 `console.log` from React components, add `.catch()` to unhandled promise chains, resolve TODO comments
- **Documentation**: Standardize Positron version (2025.6.0+), update setup flow, add OO API as recommended pattern, fix non-existent function reference

## Test plan

- [x] All 803 Python tests pass (68.36% coverage)
- [x] All 569 TypeScript tests pass
- [x] Python linting passes (ruff)
- [x] TypeScript linting passes (eslint)
- [x] Extension builds successfully (3.55 MB .vsix)
- [ ] Manual: Load POD5 + BAM in Positron, verify plots still render
- [ ] Manual: Check that debug logging appears when expected (e.g., missing FASTA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)