### PR TITLE
feat: per-sample base-call pileup in multi-sample composite plot

### DIFF
--- a/squiggy/plot_strategies/aggregate_comparison.py
+++ b/squiggy/plot_strategies/aggregate_comparison.py
@@ -402,6 +402,40 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         return p
 
+    def _create_pileup_tracks(
+        self, samples: list[dict], rna_mode: bool = False
+    ) -> list:
+        """
+        Create one base-call pileup track per sample
+
+        Reuses the single-sample pileup renderer from AggregatePlotStrategy so the
+        stacked-base appearance matches the single-sample composite plot. Each track
+        is titled with its sample name.
+
+        Args:
+            samples: List of sample data dicts, each optionally with 'pileup_stats'
+            rna_mode: If True, display U instead of T for RNA sequences
+
+        Returns:
+            List of Bokeh figures (one per sample with pileup data); may be empty
+        """
+        # Local import avoids a circular import between the two strategy modules
+        from .aggregate import AggregatePlotStrategy
+
+        agg = AggregatePlotStrategy(self.theme)
+
+        tracks = []
+        for sample in samples:
+            pileup_stats = sample.get("pileup_stats")
+            if not pileup_stats or len(pileup_stats.get("positions", [])) == 0:
+                continue
+
+            fig = agg._create_pileup_track(pileup_stats, rna_mode=rna_mode)
+            fig.title.text = f"Base Call Pileup — {sample['name']}"
+            tracks.append(fig)
+
+        return tracks
+
     def _create_coverage_track(self, samples: list[dict], reference_name: str):
         """
         Create coverage comparison track
@@ -527,6 +561,14 @@ class AggregateComparisonStrategy(PlotStrategy):
             signal_track = self._create_signal_track(samples, reference_name)
             if signal_track:
                 tracks.append(signal_track)
+
+        # Per-sample base-call pileup tracks (the most important comparison panel)
+        if data.get("show_pileup"):
+            tracks.extend(
+                self._create_pileup_tracks(
+                    samples, rna_mode=data.get("rna_mode", False)
+                )
+            )
 
         if "dwell_time" in enabled_metrics:
             dwell_track = self._create_dwell_track(samples, reference_name)

--- a/squiggy/plotting.py
+++ b/squiggy/plotting.py
@@ -1733,6 +1733,8 @@ def plot_aggregate_comparison(
     theme: str = "LIGHT",
     sample_colors: dict[str, str] | None = None,
     trim_primers: bool = True,
+    show_pileup: bool = True,
+    rna_mode: bool = False,
 ) -> str:
     """
     Generate aggregate comparison plot for multiple samples
@@ -1755,6 +1757,9 @@ def plot_aggregate_comparison(
         theme: Color theme (LIGHT, DARK)
         sample_colors: Optional dict mapping sample names to hex colors.
                        If None, uses Okabe-Ito palette (default)
+        trim_primers: Trim primer/adapter regions using FASTA body bounds (default True)
+        show_pileup: Add one base-call pileup track per sample (default True)
+        rna_mode: Display U instead of T in pileup tracks for RNA sequences (default False)
 
     Returns:
         Bokeh HTML string with aggregate comparison visualization
@@ -1929,6 +1934,15 @@ def plot_aggregate_comparison(
             quality_stats = calculate_quality_by_position(reads)
             sample_stats["quality_stats"] = quality_stats
 
+        # Calculate base-call pileup (rendered as one track per sample)
+        if show_pileup:
+            sample_stats["pileup_stats"] = calculate_base_pileup(
+                reads,
+                bam_file=sample._bam_path,
+                reference_name=reference_name,
+                fasta_file=sample._fasta_path,
+            )
+
         sample_data.append(sample_stats)
 
     # Prepare data for AggregateComparisonStrategy
@@ -1937,6 +1951,8 @@ def plot_aggregate_comparison(
         "reference_name": reference_name,
         "enabled_metrics": metrics,
         "primer_trim_bounds": primer_trim_bounds,
+        "show_pileup": show_pileup,
+        "rna_mode": rna_mode,
     }
 
     options = {"normalization": norm_method}

--- a/src/backend/__tests__/squiggy-runtime-api.test.ts
+++ b/src/backend/__tests__/squiggy-runtime-api.test.ts
@@ -149,6 +149,42 @@ describe('SquiggyRuntimeAPI', () => {
         });
     });
 
+    describe('generateAggregateComparison', () => {
+        it('should emit show_pileup and rna_mode in the Python call', async () => {
+            await api.generateAggregateComparison(['s1', 's2'], 'chr1');
+
+            expect(mockClient.executeSilent).toHaveBeenCalled();
+            const code = mockClient.executeSilent.mock.calls[0][0] as string;
+            expect(code).toContain('plot_aggregate_comparison(');
+            // Defaults: show_pileup true, rna_mode false
+            expect(code).toContain('show_pileup=True');
+            expect(code).toContain('rna_mode=False');
+        });
+
+        it('should honor showPileup=false and rnaMode=true', async () => {
+            await api.generateAggregateComparison(
+                ['s1', 's2'],
+                'chr1',
+                ['signal'],
+                null,
+                'ZNORM',
+                'LIGHT',
+                undefined,
+                true,
+                false, // showPileup
+                true // rnaMode
+            );
+
+            const code = mockClient.executeSilent.mock.calls[0][0] as string;
+            expect(code).toContain('show_pileup=False');
+            expect(code).toContain('rna_mode=True');
+        });
+
+        it('should throw for fewer than 2 samples', async () => {
+            await expect(api.generateAggregateComparison(['s1'], 'chr1')).rejects.toThrow();
+        });
+    });
+
     describe('loadFASTA', () => {
         it('should load FASTA file', async () => {
             await api.loadFASTA('/path/file.fasta');

--- a/src/backend/squiggy-runtime-api.ts
+++ b/src/backend/squiggy-runtime-api.ts
@@ -1342,6 +1342,8 @@ squiggy.plot_delta_comparison(
      * @param normalization - Normalization method (ZNORM, MAD, MEDIAN, NONE)
      * @param theme - Color theme (LIGHT or DARK)
      * @param sampleColors - Optional object mapping sample names to hex colors
+     * @param showPileup - Add one base-call pileup track per sample (default true)
+     * @param rnaMode - Display U instead of T in pileup tracks (default false)
      */
     async generateAggregateComparison(
         sampleNames: string[],
@@ -1351,7 +1353,9 @@ squiggy.plot_delta_comparison(
         normalization: string = 'ZNORM',
         theme: string = 'LIGHT',
         sampleColors?: Record<string, string>,
-        trimPrimers: boolean = true
+        trimPrimers: boolean = true,
+        showPileup: boolean = true,
+        rnaMode: boolean = false
     ): Promise<void> {
         // Validate input
         if (!sampleNames || sampleNames.length < 2) {
@@ -1389,7 +1393,9 @@ squiggy.plot_aggregate_comparison(
     metrics=${metricsJson},
     normalization='${normalization}',
     theme='${theme}',
-    trim_primers=${trimPrimers ? 'True' : 'False'}${maxReadsParam}${sampleColorsParam}
+    trim_primers=${trimPrimers ? 'True' : 'False'},
+    show_pileup=${showPileup ? 'True' : 'False'},
+    rna_mode=${rnaMode ? 'True' : 'False'}${maxReadsParam}${sampleColorsParam}
 )
 `;
 

--- a/src/commands/plot-commands.ts
+++ b/src/commands/plot-commands.ts
@@ -778,6 +778,8 @@ async function plotAggregateComparison(
             // Get plot options
             const options = state.plotOptionsProvider?.getOptions();
             const normalization = options?.normalization || 'ZNORM';
+            const showPileup = options?.showPileup ?? true;
+            const rnaMode = options?.rnaMode ?? false;
 
             // Detect theme from VSCode settings
             const isDark = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark;
@@ -802,7 +804,9 @@ async function plotAggregateComparison(
                 normalization,
                 theme,
                 Object.keys(sampleColors).length > 0 ? sampleColors : undefined,
-                options?.trimPrimers ?? true
+                options?.trimPrimers ?? true,
+                showPileup,
+                rnaMode
             );
         },
         ErrorContext.PLOT_GENERATE,

--- a/tests/test_aggregate_comparison_strategy.py
+++ b/tests/test_aggregate_comparison_strategy.py
@@ -759,3 +759,129 @@ class TestAggregateComparisonIntegration:
 
         assert isinstance(html, str)
         assert isinstance(grid, GridPlot)
+
+
+def _make_pileup_stats(positions, ref_bases=None):
+    """Build a minimal pileup_stats dict in the shape _create_pileup_track expects"""
+    counts = {int(p): {"A": 10, "C": 2, "G": 1, "T": 7} for p in positions}
+    stats = {"positions": np.array(positions), "counts": counts}
+    if ref_bases is not None:
+        stats["reference_bases"] = {int(p): b for p, b in ref_bases.items()}
+    return stats
+
+
+class TestPerSamplePileupTracks:
+    """Tests for per-sample base-call pileup tracks in the comparison plot"""
+
+    @pytest.fixture
+    def data_with_pileup(self):
+        """Two samples with signal + pileup stats"""
+        positions = np.arange(20)
+        return {
+            "samples": [
+                {
+                    "name": "sample_A",
+                    "signal_stats": {
+                        "positions": positions,
+                        "mean_signal": np.random.randn(20),
+                        "std_signal": np.full(20, 0.2),
+                    },
+                    "pileup_stats": _make_pileup_stats(positions),
+                },
+                {
+                    "name": "sample_B",
+                    "signal_stats": {
+                        "positions": positions,
+                        "mean_signal": np.random.randn(20),
+                        "std_signal": np.full(20, 0.2),
+                    },
+                    "pileup_stats": _make_pileup_stats(positions),
+                },
+            ],
+            "reference_name": "chr1:1000-1020",
+            "enabled_metrics": ["signal"],
+            "show_pileup": True,
+            "rna_mode": False,
+        }
+
+    def _pileup_titles(self, grid):
+        return [
+            fig.title.text
+            for fig, _row, _col in grid.children
+            if "Base Call Pileup" in fig.title.text
+        ]
+
+    def test_pileup_track_per_sample_when_enabled(self, data_with_pileup):
+        """One pileup track per sample is added when show_pileup is True"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        _, grid = strategy.create_plot(data_with_pileup, {})
+
+        titles = self._pileup_titles(grid)
+        assert len(titles) == 2
+        assert any("sample_A" in t for t in titles)
+        assert any("sample_B" in t for t in titles)
+
+    def test_no_pileup_tracks_when_disabled(self, data_with_pileup):
+        """No pileup tracks are added when show_pileup is False"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        data_with_pileup["show_pileup"] = False
+        _, grid = strategy.create_plot(data_with_pileup, {})
+
+        assert self._pileup_titles(grid) == []
+
+    def test_no_pileup_tracks_when_flag_absent(self, data_with_pileup):
+        """Backward compatible: absent show_pileup key yields no pileup tracks"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        del data_with_pileup["show_pileup"]
+        _, grid = strategy.create_plot(data_with_pileup, {})
+
+        assert self._pileup_titles(grid) == []
+
+    def test_sample_without_pileup_is_skipped(self, data_with_pileup):
+        """A sample lacking pileup data is skipped, others still rendered"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        data_with_pileup["samples"][1].pop("pileup_stats")
+        _, grid = strategy.create_plot(data_with_pileup, {})
+
+        titles = self._pileup_titles(grid)
+        assert len(titles) == 1
+        assert "sample_A" in titles[0]
+
+    def test_empty_pileup_positions_skipped(self, data_with_pileup):
+        """A sample with empty pileup positions is skipped"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        data_with_pileup["samples"][0]["pileup_stats"] = {
+            "positions": np.array([]),
+            "counts": {},
+        }
+        _, grid = strategy.create_plot(data_with_pileup, {})
+
+        titles = self._pileup_titles(grid)
+        assert len(titles) == 1
+        assert "sample_B" in titles[0]
+
+    def test_pileup_tracks_share_x_range(self, data_with_pileup):
+        """Pileup tracks are x-linked with the rest of the comparison tracks"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        _, grid = strategy.create_plot(data_with_pileup, {})
+
+        figures = [fig for fig, _row, _col in grid.children]
+        first_x_range = figures[0].x_range
+        for fig in figures[1:]:
+            assert fig.x_range is first_x_range
+
+    def test_rna_mode_displays_u(self, data_with_pileup):
+        """RNA mode renders the pileup track with U legend instead of T"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        data_with_pileup["rna_mode"] = True
+        html, _ = strategy.create_plot(data_with_pileup, {})
+
+        assert isinstance(html, str)
+        assert len(html) > 0


### PR DESCRIPTION
## Summary

The base-call pileup track — the most important panel of the composite read plot — disappeared when 2+ samples were selected. Root cause: the single-sample composite plot (`plot_aggregate` → `AggregatePlotStrategy`) builds the pileup, but the 2+ sample **Overlay** path (`plot_aggregate_comparison` → `AggregateComparisonStrategy`) overlays mean signal/dwell/quality/coverage and never computed a pileup, so the existing **Base pileup** checkbox was silently ignored on that path. (Not a regression — this path never had a pileup.)

This adds **one stacked-base pileup track per sample** beneath the signal overlay in the Overlay comparison, reusing the single-sample renderer so the appearance matches.

- `plot_aggregate_comparison()` gains `show_pileup`/`rna_mode`; computes `calculate_base_pileup` per sample and passes flags to the strategy.
- `AggregateComparisonStrategy._create_pileup_tracks()` reuses `AggregatePlotStrategy._create_pileup_track`, titles each track `Base Call Pileup — <sample>`, and inserts them right after the signal overlay (auto x-linked).
- Threaded `showPileup`/`rnaMode` through `generateAggregateComparison` (TS) and `plotAggregateComparison`, sourced from the existing plot options. No `extension.ts` or message-type changes.

The separate stubbed "Multi-Track (Detailed)" view style is intentionally left unimplemented.

## Test plan

- [x] Python: full suite passes (810 passed, 2 skipped, 67.9% coverage); 7 new tests in `tests/test_aggregate_comparison_strategy.py` (pileup track per sample, off when disabled/absent, sample-skipping, x-range linking, RNA mode).
- [x] TypeScript: `squiggy-runtime-api` (3 new comparison tests) and `plot-commands` pass; ruff + prettier clean.
- [ ] Manual (F5 Extension Dev Host): demo session → select both samples → Composite Read Plots → ensure **Base pileup** checked → Generate → confirm a `Base Call Pileup — <sample>` track per sample, x-aligned under the signal overlay, U shown for RNA. Untick → regenerate → tracks disappear. Single-sample path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)