### PR TITLE
Show consensus base letters atop reference overlay plot

### DIFF
--- a/squiggy/plot_strategies/reference_overlay.py
+++ b/squiggy/plot_strategies/reference_overlay.py
@@ -281,6 +281,14 @@ class ReferenceOverlayPlotStrategy(PlotStrategy):
                 fig, consensus_map, signal_min, signal_max, x_map=x_map
             )
 
+            # Draw consensus base letters inline at the top of the plot.
+            # Skipped when a dedicated FASTA reference track is rendered below
+            # (see _create_reference_track) to avoid duplicating the sequence.
+            if consensus_map and not reference_sequence:
+                self._add_consensus_base_letters(
+                    fig, consensus_map, signal_min, signal_max, x_map=x_map
+                )
+
         # Add hover tool
         if all_renderers:
             hover = HoverTool(
@@ -468,6 +476,46 @@ class ReferenceOverlayPlotStrategy(PlotStrategy):
             show_labels=False,
         )
         renderer._add_base_type_patches(fig, base_regions)
+
+    def _add_consensus_base_letters(
+        self,
+        fig,
+        consensus_map: dict[int, str],
+        signal_min: float,
+        signal_max: float,
+        x_map: dict[int, DwellXCoord] | None = None,
+    ) -> None:
+        """
+        Draw consensus base letters in a band above the signal, colored by base.
+
+        Mirrors the composite (aggregate) plot's inline base track. Extends the
+        figure y-range to make headroom so letters are not clipped.
+        """
+        from bokeh.models import Range1d
+
+        positions = sorted(consensus_map.keys())
+        consensus_seq = "".join(consensus_map[p] for p in positions)
+
+        if x_map:
+            letter_x = [
+                x_map[p].center if p in x_map else float(p) for p in positions
+            ]
+        else:
+            letter_x = [float(p) for p in positions]
+
+        span = signal_max - signal_min
+        if span == 0:
+            span = 1.0
+        letter_y = signal_max + span * 0.02
+
+        fig.y_range = Range1d(
+            start=signal_min - span * 0.05, end=signal_max + span * 0.12
+        )
+
+        ref_renderer = ReferenceTrackRenderer(self.theme_manager)
+        ref_renderer.add_reference_labels_to_plot(
+            fig, consensus_seq, letter_x, y_position=letter_y
+        )
 
     # =========================================================================
     # Private Methods: Dwell Scaling

--- a/tests/test_reference_overlay_strategy.py
+++ b/tests/test_reference_overlay_strategy.py
@@ -4,6 +4,8 @@ Tests for ReferenceOverlayPlotStrategy
 
 import numpy as np
 import pytest
+from bokeh.models import GlyphRenderer
+from bokeh.models.glyphs import Text
 from bokeh.models.plots import Plot
 
 from squiggy.constants import NormalizationMethod, Theme
@@ -425,6 +427,55 @@ class TestReferenceTrack:
         data = make_data(num_reads=1)
         _, fig = strategy.create_plot(data, {})
         assert isinstance(fig, Plot)
+
+
+# =============================================================================
+# Test: Consensus Base Letters
+# =============================================================================
+
+
+def _collect_letter_texts(fig) -> list[str]:
+    """Collect text values from all Text glyph renderers on a figure."""
+    texts: list[str] = []
+    for r in fig.renderers:
+        if isinstance(r, GlyphRenderer) and isinstance(r.glyph, Text):
+            texts.extend(list(r.data_source.data.get("text", [])))
+    return texts
+
+
+class TestConsensusBaseLetters:
+    def test_letters_rendered_when_show_labels(self):
+        """Consensus base letters appear inline when show_labels is True."""
+        strategy = ReferenceOverlayPlotStrategy(Theme.LIGHT)
+        data = make_data(num_reads=3, sequence="ACGT")
+        _, fig = strategy.create_plot(data, {"show_labels": True})
+        assert _collect_letter_texts(fig) == ["A", "C", "G", "T"]
+
+    def test_letters_rendered_with_dwell_scaling(self):
+        """Letters still render (one per position) when x is dwell-scaled."""
+        strategy = ReferenceOverlayPlotStrategy(Theme.LIGHT)
+        data = make_data(num_reads=3, sequence="ACGT")
+        _, fig = strategy.create_plot(
+            data, {"show_labels": True, "scale_x_by_dwell": True}
+        )
+        assert _collect_letter_texts(fig) == ["A", "C", "G", "T"]
+
+    def test_no_letters_when_show_labels_false(self):
+        """No base letters are drawn when show_labels is False."""
+        strategy = ReferenceOverlayPlotStrategy(Theme.LIGHT)
+        data = make_data(num_reads=3, sequence="ACGT")
+        _, fig = strategy.create_plot(data, {"show_labels": False})
+        assert _collect_letter_texts(fig) == []
+
+    def test_no_inline_letters_when_reference_track_present(self):
+        """A FASTA reference track suppresses inline consensus letters."""
+        strategy = ReferenceOverlayPlotStrategy(Theme.LIGHT)
+        data = make_data(num_reads=2, genomic_start=0)
+        data["reference_sequence"] = "ACGTACGTACGTACGT" * 100
+        _, layout = strategy.create_plot(data, {"show_labels": True})
+        # Inline letters live on the main figure; it must carry no Text glyphs.
+        main_fig = layout.main_plot
+        assert _collect_letter_texts(main_fig) == []
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- In the **Per-Read Plots → Reference overlay** view, each genomic position is shaded with a colored band representing the consensus base, but no letter was shown — making the sequence hard to read.
- Root cause: the data dict assembled for `REFERENCE_OVERLAY` in `plotting.py` never includes `reference_sequence`, so the strategy's reference-track path never fired and no letters were ever drawn.
- Now draws the consensus base letter at each genomic position **inline at the top** of the plot, colored to match the bands — mirroring how the composite (aggregate) plot shows bases.

## Implementation
- `squiggy/plot_strategies/reference_overlay.py`: new `_add_consensus_base_letters` helper, called from `create_plot` after the consensus color bands. Handles dwell-scaled x-coordinates, adds y-range headroom so letters aren't clipped, and reuses `ReferenceTrackRenderer.add_reference_labels_to_plot()` for per-base coloring.
- Suppressed when a dedicated FASTA reference track is rendered (`not reference_sequence`) to avoid duplicating the sequence.
- The letters reflect the **consensus** base (majority vote across overlaid reads) — exactly what the existing colored bands already represent.

## Test plan
- [x] `pytest tests/test_reference_overlay_strategy.py` — added `TestConsensusBaseLetters` covering: letters present with `show_labels=True`, present under dwell-scaling, absent when `show_labels=False`, and absent on the main figure when a FASTA reference track is present.
- [ ] Manual (Positron): load POD5 + BAM, select multiple reads, choose Per-Read Plots → Reference overlay, and confirm colored letters appear at the top aligned over the matching bands (incl. scale-by-dwell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)