### PR TITLE
fix: auto-expand references on read-ID search (#78)

### DIFF
--- a/src/views/components/__tests__/reads-filter.test.ts
+++ b/src/views/components/__tests__/reads-filter.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the reads panel filter logic (filterItems).
+ */
+
+import { filterItems } from '../reads-filter';
+import { ReadItem, ReferenceGroupItem, ReadListItem } from '../../../types/squiggy-reads-types';
+
+const ref = (referenceName: string, readCount: number): ReferenceGroupItem => ({
+    type: 'reference',
+    referenceName,
+    readCount,
+    isExpanded: false,
+    indentLevel: 0,
+});
+
+const read = (readId: string, referenceName?: string): ReadItem => ({
+    type: 'read',
+    readId,
+    referenceName,
+    indentLevel: 0,
+});
+
+describe('filterItems', () => {
+    it('returns items unchanged when search text is empty', () => {
+        const items: ReadListItem[] = [ref('chr1', 2)];
+        expect(filterItems(items, '', new Map(), 'read')).toBe(items);
+    });
+
+    describe('reference mode', () => {
+        it('keeps only references whose name matches', () => {
+            const items: ReadListItem[] = [ref('chr1', 2), ref('chr2', 3)];
+            const result = filterItems(items, 'chr2', new Map(), 'reference');
+            expect(result).toEqual([ref('chr2', 3)]);
+        });
+
+        it('matches reference of flat read items', () => {
+            const items: ReadListItem[] = [read('r1', 'chr1'), read('r2', 'chr2')];
+            const result = filterItems(items, 'chr1', new Map(), 'reference');
+            expect(result).toEqual([read('r1', 'chr1')]);
+        });
+    });
+
+    describe('read mode (grouped)', () => {
+        const items: ReadListItem[] = [ref('chr1', 2), ref('chr2', 1)];
+        const map = new Map<string, ReadItem[]>([
+            ['chr1', [read('read_aaa'), read('read_bbb')]],
+            ['chr2', [read('read_ccc')]],
+        ]);
+
+        it('auto-expands matching references and lists matching reads beneath them (#78)', () => {
+            const result = filterItems(items, 'read_aaa', map, 'read');
+
+            // chr1 header (expanded, readCount = 1 match) followed by the matching read.
+            expect(result).toHaveLength(2);
+            const header = result[0] as ReferenceGroupItem;
+            expect(header.type).toBe('reference');
+            expect(header.referenceName).toBe('chr1');
+            expect(header.isExpanded).toBe(true);
+            expect(header.readCount).toBe(1);
+
+            const matched = result[1] as ReadItem;
+            expect(matched.type).toBe('read');
+            expect(matched.readId).toBe('read_aaa');
+            expect(matched.indentLevel).toBe(1);
+        });
+
+        it('drops references with no matching reads', () => {
+            const result = filterItems(items, 'read_ccc', map, 'read');
+            expect(result).toHaveLength(2);
+            expect((result[0] as ReferenceGroupItem).referenceName).toBe('chr2');
+            expect((result[1] as ReadItem).readId).toBe('read_ccc');
+        });
+
+        it('lists every matching read under a reference', () => {
+            const result = filterItems(items, 'read_', map, 'read');
+            // chr1: header + 2 reads; chr2: header + 1 read = 5 items
+            expect(result).toHaveLength(5);
+            const readIds = result
+                .filter((i): i is ReadItem => i.type === 'read')
+                .map((r) => r.readId);
+            expect(readIds).toEqual(['read_aaa', 'read_bbb', 'read_ccc']);
+        });
+    });
+
+    describe('read mode (flat POD5)', () => {
+        it('matches read IDs directly', () => {
+            const items: ReadListItem[] = [read('alpha'), read('beta')];
+            const result = filterItems(items, 'alph', new Map(), 'read');
+            expect(result).toEqual([read('alpha')]);
+        });
+    });
+});

--- a/src/views/components/reads-filter.ts
+++ b/src/views/components/reads-filter.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure filtering helpers for the reads panel.
+ *
+ * Extracted from squiggy-reads-core.tsx so the search/filter logic can be unit
+ * tested without the React/webview module dependencies.
+ */
+
+import { ReadListItem, ReadItem } from '../../types/squiggy-reads-types';
+
+/**
+ * Filter the reads list by search text.
+ *
+ * Two modes:
+ * - 'reference': match reference names (grouped mode) or a read's reference (flat mode).
+ * - 'read': match read IDs. In grouped mode, references with matching reads are
+ *   auto-expanded and the matching reads are listed beneath their header so results
+ *   are shown in reference context (#78). In grouped mode `items` only contains
+ *   reference headers, so the matching reads are sourced from `referenceToReads`
+ *   and never double-listed.
+ */
+export function filterItems(
+    items: ReadListItem[],
+    searchText: string,
+    referenceToReads: Map<string, ReadItem[]>,
+    searchMode: 'reference' | 'read'
+): ReadListItem[] {
+    if (!searchText) {
+        return items;
+    }
+
+    const searchLower = searchText.toLowerCase();
+    const filtered: ReadListItem[] = [];
+
+    for (const item of items) {
+        if (item.type === 'reference') {
+            const refMatches = item.referenceName.toLowerCase().includes(searchLower);
+
+            // In reference mode, only match reference names
+            if (searchMode === 'reference') {
+                if (refMatches) {
+                    filtered.push(item);
+                }
+            } else {
+                // In read mode, check individual reads
+                const reads = referenceToReads.get(item.referenceName) || [];
+                const matchingReads = reads.filter((read) =>
+                    read.readId.toLowerCase().includes(searchLower)
+                );
+
+                if (matchingReads.length > 0) {
+                    // Auto-expand the reference and list the matching reads beneath
+                    // it, so read-ID search shows results in their reference context
+                    // rather than behind a collapsed header (#78). In grouped mode
+                    // `items` only contains reference headers, so this does not
+                    // double-list reads.
+                    filtered.push({
+                        ...item,
+                        readCount: matchingReads.length,
+                        isExpanded: true,
+                    });
+                    for (const read of matchingReads) {
+                        filtered.push({ ...read, indentLevel: 1 });
+                    }
+                }
+            }
+        } else {
+            // For flat list (POD5-only)
+            if (searchMode === 'reference') {
+                // Search in reference name if available
+                if (item.referenceName && item.referenceName.toLowerCase().includes(searchLower)) {
+                    filtered.push(item);
+                }
+            } else {
+                // Search in read ID
+                if (item.readId.toLowerCase().includes(searchLower)) {
+                    filtered.push(item);
+                }
+            }
+        }
+    }
+
+    return filtered;
+}

--- a/src/views/components/squiggy-reads-core.tsx
+++ b/src/views/components/squiggy-reads-core.tsx
@@ -14,6 +14,7 @@ import {
     CONSTANTS,
 } from '../../types/squiggy-reads-types';
 import { ReadsInstance } from './squiggy-reads-instance';
+import { filterItems } from './reads-filter';
 import { vscode } from './vscode-api';
 import './squiggy-reads-core.css';
 
@@ -636,66 +637,6 @@ export const ReadsCore: React.FC = () => {
         </div>
     );
 };
-
-/**
- * Filter items based on search text
- * NOTE: This is only used for flat POD5-only mode
- * For BAM+POD5 grouped mode, rebuildItemsList handles filtering
- */
-function filterItems(
-    items: ReadListItem[],
-    searchText: string,
-    referenceToReads: Map<string, ReadItem[]>,
-    searchMode: 'reference' | 'read'
-): ReadListItem[] {
-    if (!searchText) {
-        return items;
-    }
-
-    const searchLower = searchText.toLowerCase();
-    const filtered: ReadListItem[] = [];
-
-    for (const item of items) {
-        if (item.type === 'reference') {
-            const refMatches = item.referenceName.toLowerCase().includes(searchLower);
-
-            // In reference mode, only match reference names
-            if (searchMode === 'reference') {
-                if (refMatches) {
-                    filtered.push(item);
-                }
-            } else {
-                // In read mode, check individual reads
-                const reads = referenceToReads.get(item.referenceName) || [];
-                const matchingReads = reads.filter((read) =>
-                    read.readId.toLowerCase().includes(searchLower)
-                );
-
-                if (matchingReads.length > 0) {
-                    filtered.push({
-                        ...item,
-                        readCount: matchingReads.length,
-                    });
-                }
-            }
-        } else {
-            // For flat list (POD5-only)
-            if (searchMode === 'reference') {
-                // Search in reference name if available
-                if (item.referenceName && item.referenceName.toLowerCase().includes(searchLower)) {
-                    filtered.push(item);
-                }
-            } else {
-                // Search in read ID
-                if (item.readId.toLowerCase().includes(searchLower)) {
-                    filtered.push(item);
-                }
-            }
-        }
-    }
-
-    return filtered;
-}
 
 /**
  * Sort reference headers in place (for lazy-loading mode)


### PR DESCRIPTION
## Summary

Restores the "search results show reads in expanded reference context" behavior from #78. Read-ID search was showing matching references as a **collapsed** header with a match count but no visible reads — the auto-expand logic originally added in `b100f4b` was lost in a later refactor of the reads panel.

`filterItems` now, in read mode, marks a matching reference as expanded and lists the matching reads beneath its header. In grouped mode the top-level `items` array contains only reference headers (reads are sourced from the reference→reads map), so this does not double-list reads.

## Changes

- Extracted the pure `filterItems` helper out of `squiggy-reads-core.tsx` into `reads-filter.ts` so it can be unit-tested without the React/webview module dependencies (the core module calls `acquireVsCodeApi()` at import time).
- Fixed the read-mode branch to auto-expand + list matching reads (#78).
- Added `reads-filter.test.ts` with regression coverage: reference mode, read mode (grouped auto-expand, the #78 case), and flat POD5 mode.

## Verification

- `tsc --noEmit`: clean
- Jest: 28 suites, 576 passed, 7 skipped (7 new tests)
- ESLint: 0 errors

## Audit context

This came out of an open-issue audit. Also resulting from that audit: #174 and #177 closed (already shipped), #144 closed (bulk sample controls already exist in the Samples panel), and a note on #148 that its duplicate-Cancel sub-bug was already fixed in `cdb3d6d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)