### PR TITLE
fix: kernel manager concurrency & lifecycle gaps (#186)

### DIFF
--- a/src/__mocks__/positron.ts
+++ b/src/__mocks__/positron.ts
@@ -9,7 +9,24 @@ export const runtime = {
     executeCode: jest.fn(),
     evaluateCode: jest.fn(),
     getSessionVariables: jest.fn(),
+    getRegisteredRuntimes: jest.fn(),
+    getPreferredRuntime: jest.fn(),
+    getActiveSessions: jest.fn(),
+    startLanguageRuntime: jest.fn(),
+    deleteSession: jest.fn(),
 };
+
+export enum RuntimeState {
+    Uninitialized = 'uninitialized',
+    Initializing = 'initializing',
+    Starting = 'starting',
+    Ready = 'ready',
+    Idle = 'idle',
+    Busy = 'busy',
+    Restarting = 'restarting',
+    Exited = 'exited',
+    Offline = 'offline',
+}
 
 export enum RuntimeCodeExecutionMode {
     Interactive = 'interactive',

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -42,6 +42,10 @@ export class EventEmitter<T> {
     fire(data: T) {
         this.listeners.forEach((l) => l(data));
     }
+
+    dispose() {
+        this.listeners = [];
+    }
 }
 
 export class ThemeIcon {

--- a/src/backend/__tests__/squiggy-kernel-manager.test.ts
+++ b/src/backend/__tests__/squiggy-kernel-manager.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for SquiggyKernelManager lifecycle (Issue #186)
+ *
+ * Focus: the concurrency guard on start() and the dispose() teardown contract.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import * as positron from 'positron';
+import { SquiggyKernelManager, SquiggyKernelState } from '../squiggy-kernel-manager';
+
+jest.mock('positron');
+jest.mock('vscode');
+
+describe('SquiggyKernelManager', () => {
+    const makeRuntime = () => ({
+        runtimeId: 'rt-squiggy',
+        runtimeName: 'Squiggy',
+        runtimeVersion: '3.12',
+        runtimePath: '/home/u/.venvs/squiggy/bin/python',
+        languageId: 'python',
+    });
+
+    // Fake session whose state-change listeners reach Ready asynchronously
+    // (mirrors the real kernel, which never fires synchronously on registration).
+    const makeSession = (sessionId = 'sess-1') => ({
+        metadata: { sessionId, sessionName: 'Squiggy Dedicated Kernel', sessionMode: 'console' },
+        onDidChangeRuntimeState: jest.fn((cb: (s: string) => void) => {
+            setTimeout(() => cb(positron.RuntimeState.Ready), 0);
+            return { dispose: jest.fn() };
+        }),
+        onDidEndSession: jest.fn(() => ({ dispose: jest.fn() })),
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (positron.runtime.getRegisteredRuntimes as any).mockResolvedValue([makeRuntime()]);
+        (positron.runtime.getPreferredRuntime as any).mockResolvedValue(makeRuntime());
+        (positron.runtime.getActiveSessions as any).mockResolvedValue([]);
+        (positron.runtime.deleteSession as any).mockResolvedValue(undefined);
+        // Reject the readiness probe ('1+1') so waitForReady resolves via the
+        // state-change event (after setState(Ready)); resolve everything else
+        // (setupPythonPath / verifySquiggyAvailable).
+        (positron.runtime.executeCode as any).mockImplementation(
+            async (_lang: string, code: string) => {
+                if (code === '1+1') {
+                    throw new Error('not ready');
+                }
+                return {};
+            }
+        );
+    });
+
+    it('coalesces concurrent start() calls into a single session', async () => {
+        (positron.runtime.startLanguageRuntime as any).mockResolvedValue(makeSession());
+
+        const mgr = new SquiggyKernelManager('/ext/path'); // no context => no reconnect
+        await Promise.all([mgr.start(), mgr.start(), mgr.start()]);
+
+        expect(positron.runtime.startLanguageRuntime).toHaveBeenCalledTimes(1);
+        expect(mgr.getState()).toBe(SquiggyKernelState.Ready);
+        expect(mgr.getSessionId()).toBe('sess-1');
+    });
+
+    it('does not start a second session once already running', async () => {
+        (positron.runtime.startLanguageRuntime as any).mockResolvedValue(makeSession());
+
+        const mgr = new SquiggyKernelManager('/ext/path');
+        await mgr.start();
+        await mgr.start(); // already running -> early return
+
+        expect(positron.runtime.startLanguageRuntime).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when start() is called after dispose()', async () => {
+        const mgr = new SquiggyKernelManager('/ext/path');
+        mgr.dispose();
+
+        await expect(mgr.start()).rejects.toThrow(/disposed/i);
+        expect(positron.runtime.startLanguageRuntime).not.toHaveBeenCalled();
+    });
+
+    it('dispose() is idempotent and deletes the session once', async () => {
+        (positron.runtime.startLanguageRuntime as any).mockResolvedValue(makeSession());
+
+        const mgr = new SquiggyKernelManager('/ext/path');
+        await mgr.start();
+
+        mgr.dispose();
+        mgr.dispose(); // second call is a no-op
+
+        expect(positron.runtime.deleteSession).toHaveBeenCalledTimes(1);
+        expect(mgr.getSessionId()).toBeUndefined();
+    });
+});

--- a/src/backend/squiggy-kernel-manager.ts
+++ b/src/backend/squiggy-kernel-manager.ts
@@ -38,6 +38,8 @@ export class SquiggyKernelManager implements RuntimeClient {
     private extensionPath: string;
     private isDisposed = false;
     private context: vscode.ExtensionContext | undefined;
+    // Coalesces concurrent start() calls so we never create two sessions
+    private startPromise: Promise<void> | null = null;
 
     readonly onDidChangeState = this.stateChangeEmitter.event;
 
@@ -104,6 +106,25 @@ export class SquiggyKernelManager implements RuntimeClient {
             return;
         }
 
+        // Coalesce concurrent start() calls. Until startLanguageRuntime()
+        // resolves, this.session is still undefined, so a second concurrent
+        // call would otherwise pass the guard above and create a second
+        // session, leaking the first.
+        if (this.startPromise) {
+            return this.startPromise;
+        }
+
+        this.startPromise = this.doStart().finally(() => {
+            this.startPromise = null;
+        });
+        return this.startPromise;
+    }
+
+    /**
+     * Internal kernel-start implementation. Always invoked via start(), which
+     * guards against concurrent and post-dispose calls.
+     */
+    private async doStart(): Promise<void> {
         this.setState(SquiggyKernelState.Starting);
 
         // Try to reconnect to an existing session first
@@ -567,10 +588,30 @@ assert hasattr(squiggy, 'plot_read'), "squiggy.plot_read not found"
 
     /**
      * Dispose of resources
+     *
+     * dispose() is synchronous (VSCode Disposable contract), but tearing down
+     * the kernel session is async. Mark disposed and drop the session reference
+     * synchronously first so any state-change/session-end handlers that fire
+     * during the async deletion short-circuit (see setState) instead of firing
+     * on the disposed emitter, then start the fire-and-forget deletion.
      */
     dispose(): void {
+        if (this.isDisposed) {
+            return;
+        }
         this.isDisposed = true;
-        this.shutdown();
+
+        const sessionId = this.getSessionId();
+        this.session = undefined;
+        this.reconnectedSessionId = undefined;
+
+        if (sessionId) {
+            logger.info('Shutting down Squiggy dedicated kernel (dispose)...');
+            Promise.resolve(positron.runtime.deleteSession(sessionId)).catch((error) =>
+                logger.error(`Error shutting down kernel during dispose: ${error}`)
+            );
+        }
+
         this.stateChangeEmitter.dispose();
     }
 
@@ -583,13 +624,27 @@ assert hasattr(squiggy, 'plot_read'), "squiggy.plot_read not found"
             throw new Error('No session to wait for');
         }
 
+        const sessionId = this.session.metadata.sessionId;
+
         return new Promise((resolve, reject) => {
             const startTime = Date.now();
+            let settled = false;
+
+            const finish = (action: () => void): void => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timeout);
+                disposable.dispose();
+                action();
+            };
 
             // Set up timeout
             const timeout = setTimeout(() => {
-                disposable.dispose();
-                reject(new Error(`Timeout waiting for kernel to be ready (${timeoutMs}ms)`));
+                finish(() =>
+                    reject(new Error(`Timeout waiting for kernel to be ready (${timeoutMs}ms)`))
+                );
             }, timeoutMs);
 
             // Listen for state changes
@@ -597,19 +652,37 @@ assert hasattr(squiggy, 'plot_read'), "squiggy.plot_read not found"
                 logger.debug(`Waiting for ready: current state = ${state}`);
 
                 if (state === positron.RuntimeState.Ready || state === positron.RuntimeState.Idle) {
-                    clearTimeout(timeout);
-                    disposable.dispose();
-                    logger.debug(`Kernel ready after ${Date.now() - startTime}ms`);
-                    resolve();
+                    finish(() => {
+                        logger.debug(`Kernel ready after ${Date.now() - startTime}ms`);
+                        resolve();
+                    });
                 } else if (
                     state === positron.RuntimeState.Exited ||
                     state === positron.RuntimeState.Offline
                 ) {
-                    clearTimeout(timeout);
-                    disposable.dispose();
-                    reject(new Error(`Kernel failed to start (state: ${state})`));
+                    finish(() => reject(new Error(`Kernel failed to start (state: ${state})`)));
                 }
             });
+
+            // Probe the kernel immediately in case it is already idle/ready: no
+            // further state-change event would fire, so the listener alone could
+            // block until the timeout. A successful execution means it is ready.
+            Promise.resolve(
+                positron.runtime.executeCode(
+                    'python',
+                    '1+1',
+                    false, // focus
+                    true, // allowIncomplete
+                    positron.RuntimeCodeExecutionMode.Silent,
+                    positron.RuntimeErrorBehavior.Continue,
+                    undefined, // observer
+                    sessionId
+                )
+            )
+                .then(() => finish(resolve))
+                .catch(() => {
+                    // Not ready yet — the state-change listener resolves/rejects.
+                });
         });
     }
 
@@ -715,6 +788,11 @@ assert hasattr(squiggy, 'plot_read'), "squiggy.plot_read not found"
      * Set state and emit event
      */
     private setState(newState: SquiggyKernelState): void {
+        // Once disposed, never touch the (disposed) emitter. State-change and
+        // session-end handlers can still fire during async teardown.
+        if (this.isDisposed) {
+            return;
+        }
         if (this.state !== newState) {
             this.state = newState;
             this.stateChangeEmitter.fire(newState);


### PR DESCRIPTION
Fixes the three lifecycle gaps in `SquiggyKernelManager` from the audit (#186).

## Fixes
1. **`start()` concurrency guard.** `this.session` isn't assigned until `startLanguageRuntime()` resolves, so two concurrent `start()` calls both passed the `if (this.session)` check and created **two** dedicated sessions, leaking the first. Added a `startPromise` that coalesces concurrent calls; the body moved to a private `doStart()`.
2. **`waitForReady()` already-ready short-circuit.** It only subscribed to *future* state-change events, so if the kernel was already Ready/Idle no event fired and it blocked for the full 10s timeout. Added an immediate `1+1` readiness probe (mirrors `PositronRuntimeClient`).
3. **`dispose()` use-after-dispose.** It disposed the state-change emitter while async shutdown was still running, so a late handler could `fire()` on a disposed emitter. `dispose()` now marks disposed + drops the session reference synchronously before the fire-and-forget deletion, is idempotent, and `setState()` short-circuits once disposed.

## Tests
Adds the **first** `SquiggyKernelManager` unit tests — concurrency guard (single session from 3 concurrent starts), already-running no-op, start-after-dispose throws, dispose idempotency — plus the small mock additions they need (`positron.RuntimeState` + runtime methods; `vscode.EventEmitter.dispose`).

## Verification
- tsc clean · Jest 521 passed / 7 skipped (+4 new) · eslint + prettier clean

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)