### PR TITLE
fix: reads table remount jank + persist column widths (#191)

### DIFF
--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -130,12 +130,27 @@ export interface SetAvailableSamplesMessage extends BaseMessage {
     selectedSample: string | null;
 }
 
+/** Webview → extension: persist user-adjusted column widths */
+export interface UpdateColumnWidthsMessage extends BaseMessage {
+    type: 'updateColumnWidths';
+    nameWidth: number;
+    detailsWidth: number;
+}
+
+/** Extension → webview: restore previously persisted column widths */
+export interface SetColumnWidthsMessage extends BaseMessage {
+    type: 'setColumnWidths';
+    nameWidth: number;
+    detailsWidth: number;
+}
+
 export type ReadsViewIncomingMessage =
     | PlotReadMessage
     | PlotAggregateMessage
     | LoadMoreReadsMessage
     | ExpandReferenceMessage
     | SelectReadExplorerSampleMessage
+    | UpdateColumnWidthsMessage
     | ReadyMessage;
 export type ReadsViewOutgoingMessage =
     | UpdateReadsMessage
@@ -143,7 +158,8 @@ export type ReadsViewOutgoingMessage =
     | AppendReadsMessage
     | SetReadsForReferenceMessage
     | SetLoadingMessage
-    | SetAvailableSamplesMessage;
+    | SetAvailableSamplesMessage
+    | SetColumnWidthsMessage;
 
 // ========== Plot Options Messages ==========
 

--- a/src/views/__tests__/squiggy-reads-panel.test.ts
+++ b/src/views/__tests__/squiggy-reads-panel.test.ts
@@ -21,6 +21,12 @@ describe('ReadsViewPane', () => {
         mockState = {
             getAllSampleNames: jest.fn().mockReturnValue(['Sample_A', 'Sample_B']),
             selectedReadExplorerSample: 'Sample_A',
+            extensionContext: {
+                workspaceState: {
+                    get: jest.fn(),
+                    update: jest.fn(),
+                },
+            },
         } as any;
 
         provider = new ReadsViewPane(extensionUri, mockState);
@@ -138,6 +144,33 @@ describe('ReadsViewPane', () => {
                 'squiggy.internal.loadReadsForSample',
                 'Sample_B'
             );
+        });
+
+        it('should persist column widths on updateColumnWidths', async () => {
+            const messageHandler = mockWebviewView.webview.onDidReceiveMessage.mock.calls[0][0];
+
+            await messageHandler({ type: 'updateColumnWidths', nameWidth: 250, detailsWidth: 120 });
+
+            expect(mockState.extensionContext.workspaceState.update).toHaveBeenCalledWith(
+                'squiggy.reads.columnWidths',
+                { nameWidth: 250, detailsWidth: 120 }
+            );
+        });
+
+        it('should restore saved column widths on ready', async () => {
+            mockState.extensionContext.workspaceState.get.mockReturnValue({
+                nameWidth: 300,
+                detailsWidth: 150,
+            });
+            const messageHandler = mockWebviewView.webview.onDidReceiveMessage.mock.calls[0][0];
+
+            await messageHandler({ type: 'ready' });
+
+            expect(mockWebviewView.webview.postMessage).toHaveBeenCalledWith({
+                type: 'setColumnWidths',
+                nameWidth: 300,
+                detailsWidth: 150,
+            });
         });
 
         it('should handle ready message and update view', async () => {

--- a/src/views/components/squiggy-reads-core.tsx
+++ b/src/views/components/squiggy-reads-core.tsx
@@ -154,6 +154,14 @@ export const ReadsCore: React.FC = () => {
                     setIsLoading(message.isLoading);
                     setLoadingMessage(message.message || '');
                     break;
+                case 'setColumnWidths':
+                    // Restore previously persisted column widths
+                    setState((prev) => ({
+                        ...prev,
+                        nameColumnWidth: message.nameWidth,
+                        detailsColumnWidth: message.detailsWidth,
+                    }));
+                    break;
                 case 'updateSearch':
                     handleSearch(message.searchText);
                     break;

--- a/src/views/components/squiggy-reads-instance.tsx
+++ b/src/views/components/squiggy-reads-instance.tsx
@@ -6,12 +6,82 @@
  */
 
 import * as React from 'react';
-import { FixedSizeList as List } from 'react-window';
-import { ReadsInstanceProps, CONSTANTS, ReferenceGroupItem } from '../../types/squiggy-reads-types';
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import {
+    ReadsInstanceProps,
+    CONSTANTS,
+    ReadListItem,
+    ReferenceGroupItem,
+} from '../../types/squiggy-reads-types';
 import { ReadItemComponent } from './squiggy-read-item';
 import { ReferenceGroupComponent } from './squiggy-reference-group';
 import { ColumnResizer } from './column-resizer';
 import './squiggy-reads-instance.css';
+
+/**
+ * Data passed to each virtualized row via react-window's `itemData`.
+ * Keeping the row renderer module-level (instead of nested in ReadsInstance)
+ * means its component identity is stable across renders, so react-window does
+ * not unmount/remount every visible row on each parent render (scroll, resize,
+ * sort). All per-render values flow through this object instead.
+ */
+interface ReadRowData {
+    items: ReadListItem[];
+    focusedIndex: number | null;
+    selectedReadIds: Set<string>;
+    nameColumnWidth: number;
+    detailsColumnWidth: number;
+    onPlotRead: (readId: string) => void;
+    onSelectRead: (readId: string, multiSelect: boolean) => void;
+    onToggleReference: (referenceName: string) => void;
+}
+
+const ReadRow = React.memo(function ReadRow({
+    index,
+    style,
+    data,
+}: ListChildComponentProps<ReadRowData>) {
+    const {
+        items,
+        focusedIndex,
+        selectedReadIds,
+        nameColumnWidth,
+        detailsColumnWidth,
+        onPlotRead,
+        onSelectRead,
+        onToggleReference,
+    } = data;
+    const item = items[index];
+    const isFocused = index === focusedIndex;
+
+    if (item.type === 'reference') {
+        return (
+            <div style={style}>
+                <ReferenceGroupComponent
+                    item={item}
+                    isEvenRow={index % 2 === 0}
+                    nameColumnWidth={nameColumnWidth}
+                    detailsColumnWidth={detailsColumnWidth}
+                    onToggle={onToggleReference}
+                />
+            </div>
+        );
+    }
+    return (
+        <div style={style}>
+            <ReadItemComponent
+                item={item}
+                isSelected={selectedReadIds.has(item.readId)}
+                isFocused={isFocused}
+                isEvenRow={index % 2 === 0}
+                nameColumnWidth={nameColumnWidth}
+                detailsColumnWidth={detailsColumnWidth}
+                onPlotRead={onPlotRead}
+                onClick={onSelectRead}
+            />
+        </div>
+    );
+});
 
 export const ReadsInstance: React.FC<ReadsInstanceProps> = ({
     items,
@@ -227,40 +297,29 @@ export const ReadsInstance: React.FC<ReadsInstanceProps> = ({
         return () => document.removeEventListener('keydown', handleKeyDown);
     }, [localFocusedIndex, items, onPlotRead, onToggleReference]);
 
-    // Row renderer for react-window (memoized for performance)
-    const Row = React.memo(({ index, style }: { index: number; style: React.CSSProperties }) => {
-        const item = items[index];
-        const isFocused = index === localFocusedIndex;
-
-        if (item.type === 'reference') {
-            return (
-                <div style={style}>
-                    <ReferenceGroupComponent
-                        item={item}
-                        isEvenRow={index % 2 === 0}
-                        nameColumnWidth={nameColumnWidth}
-                        detailsColumnWidth={detailsColumnWidth}
-                        onToggle={onToggleReference}
-                    />
-                </div>
-            );
-        } else {
-            return (
-                <div style={style}>
-                    <ReadItemComponent
-                        item={item}
-                        isSelected={selectedReadIds.has(item.readId)}
-                        isFocused={isFocused}
-                        isEvenRow={index % 2 === 0}
-                        nameColumnWidth={nameColumnWidth}
-                        detailsColumnWidth={detailsColumnWidth}
-                        onPlotRead={onPlotRead}
-                        onClick={onSelectRead}
-                    />
-                </div>
-            );
-        }
-    });
+    // Per-render data handed to the (stable, module-level) ReadRow renderer.
+    const itemData = React.useMemo<ReadRowData>(
+        () => ({
+            items,
+            focusedIndex: localFocusedIndex,
+            selectedReadIds,
+            nameColumnWidth,
+            detailsColumnWidth,
+            onPlotRead,
+            onSelectRead,
+            onToggleReference,
+        }),
+        [
+            items,
+            localFocusedIndex,
+            selectedReadIds,
+            nameColumnWidth,
+            detailsColumnWidth,
+            onPlotRead,
+            onSelectRead,
+            onToggleReference,
+        ]
+    );
 
     return (
         <div className="reads-instance-container" ref={containerRef}>
@@ -298,8 +357,9 @@ export const ReadsInstance: React.FC<ReadsInstanceProps> = ({
                         overscanCount={CONSTANTS.OVERSCAN_COUNT}
                         onItemsRendered={handleItemsRendered}
                         onScroll={handleScroll}
+                        itemData={itemData}
                     >
-                        {Row}
+                        {ReadRow}
                     </List>
 
                     {/* Sticky header overlay */}

--- a/src/views/squiggy-reads-panel.ts
+++ b/src/views/squiggy-reads-panel.ts
@@ -16,6 +16,7 @@ import { logger } from '../utils/logger';
 
 export class ReadsViewPane extends BaseWebviewProvider {
     public static readonly viewType = 'squiggyReadList';
+    private static readonly COLUMN_WIDTHS_KEY = 'squiggy.reads.columnWidths';
 
     private _hasReferences: boolean = false;
     private _readItems: ReadListItem[] = [];
@@ -65,10 +66,39 @@ export class ReadsViewPane extends BaseWebviewProvider {
                     message.sampleName
                 );
                 break;
+            case 'updateColumnWidths':
+                // Persist user-adjusted column widths so they survive reloads
+                this.saveColumnWidths(message.nameWidth, message.detailsWidth);
+                break;
             case 'ready':
-                // Webview is ready, send initial state
+                // Webview is ready: restore persisted column widths, then send state
+                this.sendSavedColumnWidths();
                 this.updateView();
                 break;
+        }
+    }
+
+    private get columnWidthsMemento(): vscode.Memento | undefined {
+        return this._state.extensionContext?.workspaceState;
+    }
+
+    private saveColumnWidths(nameWidth: number, detailsWidth: number): void {
+        this.columnWidthsMemento?.update(ReadsViewPane.COLUMN_WIDTHS_KEY, {
+            nameWidth,
+            detailsWidth,
+        });
+    }
+
+    private sendSavedColumnWidths(): void {
+        const saved = this.columnWidthsMemento?.get<{ nameWidth: number; detailsWidth: number }>(
+            ReadsViewPane.COLUMN_WIDTHS_KEY
+        );
+        if (saved) {
+            this.postMessage({
+                type: 'setColumnWidths',
+                nameWidth: saved.nameWidth,
+                detailsWidth: saved.detailsWidth,
+            });
         }
     }
 


### PR DESCRIPTION
Fixes the two reads-table issues from the audit (#191).

## 1. react-window remount jank
`Row` was defined **inside** `ReadsInstance`, so it got a fresh component identity on every parent render (scroll, resize, sort). react-window then saw a new component *type* and unmounted/remounted every visible row — visible jank, and `React.memo` was useless. Moved the renderer to a stable module-level `ReadRow` and pass per-render values through react-window's `itemData` (memoized).

## 2. Column widths didn't persist
The webview posted `{ type: 'updateColumnWidths' }`, but the type wasn't in `ReadsViewIncomingMessage` and `ReadsViewPane` had no handler — so widths silently reset on every panel reload. Added the message types, persisted widths to `workspaceState`, and restored them to the webview on `ready` via a new `setColumnWidths` message.

## Tests
Adds `ReadsViewPane` tests for persisting (`updateColumnWidths` → `workspaceState.update`) and restoring (`ready` → `setColumnWidths` postMessage) column widths.

## Verification
- tsc clean · Jest 519 passed / 7 skipped (+2 new) · eslint + prettier clean

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)