### PR TITLE
refactor: route session/state command errors through handleError (#189)

### DIFF
--- a/src/commands/__tests__/session-commands.test.ts
+++ b/src/commands/__tests__/session-commands.test.ts
@@ -149,8 +149,8 @@ describe('Session Commands', () => {
 
             await saveSessionCommand(mockState, mockContext);
 
-            // Errors now shown via status bar, not pop-up
-            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            // Errors are surfaced via handleError (notification + log)
+            expect(vscode.window.showErrorMessage).toHaveBeenCalled();
         });
     });
 
@@ -206,8 +206,8 @@ describe('Session Commands', () => {
 
             await restoreSessionCommand(mockState, mockContext);
 
-            // Errors now shown via status bar, not pop-up
-            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            // Errors are surfaced via handleError (notification + log)
+            expect(vscode.window.showErrorMessage).toHaveBeenCalled();
         });
     });
 
@@ -285,8 +285,8 @@ describe('Session Commands', () => {
 
             await importSessionCommand(mockState, mockContext);
 
-            // Errors now shown via status bar, not pop-up
-            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            // Errors are surfaced via handleError (notification + log)
+            expect(vscode.window.showErrorMessage).toHaveBeenCalled();
         });
 
         it('should not import when user cancels file dialog', async () => {
@@ -323,8 +323,8 @@ describe('Session Commands', () => {
 
             await clearSessionCommand(mockContext);
 
-            // Errors now shown via status bar, not pop-up
-            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            // Errors are surfaced via handleError (notification + log)
+            expect(vscode.window.showErrorMessage).toHaveBeenCalled();
         });
     });
 
@@ -365,8 +365,8 @@ describe('Session Commands', () => {
 
             await loadDemoSessionCommand(mockState, mockContext);
 
-            // Errors now shown via status bar, not pop-up
-            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            // Errors are surfaced via handleError (notification + log)
+            expect(vscode.window.showErrorMessage).toHaveBeenCalled();
         });
     });
 });

--- a/src/commands/__tests__/state-commands.test.ts
+++ b/src/commands/__tests__/state-commands.test.ts
@@ -211,8 +211,8 @@ describe('State Commands', () => {
 
             await handler!();
 
-            // Errors now shown via status bar, not pop-up
-            expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+            // Errors are surfaced via handleError (notification + log)
+            expect(vscode.window.showErrorMessage).toHaveBeenCalled();
 
             // Should still clear loading state
             expect(mockState.readsViewPane.setLoading).toHaveBeenCalledWith(false);

--- a/src/commands/session-commands.ts
+++ b/src/commands/session-commands.ts
@@ -20,6 +20,7 @@ import {
 } from '../state/pipeline-session-detector';
 import { logger } from '../utils/logger';
 import { statusBarMessenger } from '../utils/status-bar-messenger';
+import { handleError, ErrorContext } from '../utils/error-handler';
 
 /**
  * Register all session management commands
@@ -85,7 +86,7 @@ export async function saveSessionCommand(
             statusBarMessenger.show('Session saved', 'save');
         }
     } catch (error) {
-        statusBarMessenger.showError(`Save failed: ${error}`);
+        handleError(error, ErrorContext.SESSION_SAVE);
     }
 }
 
@@ -145,7 +146,7 @@ export async function restoreSessionCommand(
             }
         );
     } catch (error) {
-        statusBarMessenger.showError(`Restore failed: ${error}`);
+        handleError(error, ErrorContext.SESSION_RESTORE);
     }
 }
 
@@ -184,7 +185,7 @@ export async function exportSessionCommand(
 
         statusBarMessenger.show('Session exported', 'export');
     } catch (error) {
-        statusBarMessenger.showError(`Export failed: ${error}`);
+        handleError(error, ErrorContext.SESSION_EXPORT);
     }
 }
 
@@ -249,7 +250,7 @@ export async function importSessionCommand(
             }
         );
     } catch (error) {
-        statusBarMessenger.showError(`Import failed: ${error}`);
+        handleError(error, ErrorContext.SESSION_IMPORT);
     }
 }
 
@@ -271,7 +272,7 @@ export async function clearSessionCommand(context: vscode.ExtensionContext): Pro
         await SessionStateManager.clearSession(context);
         statusBarMessenger.show('Session cleared', 'trash');
     } catch (error) {
-        statusBarMessenger.showError(`Clear failed: ${error}`);
+        handleError(error, ErrorContext.SESSION_CLEAR);
     }
 }
 
@@ -317,8 +318,7 @@ export async function loadDemoSessionCommand(
 
         logger.info('Demo session loaded successfully');
     } catch (error) {
-        logger.error('Failed to load demo session', error);
-        statusBarMessenger.showError(`Demo load failed: ${error}`);
+        handleError(error, ErrorContext.DEMO_LOAD);
     }
 }
 
@@ -366,7 +366,7 @@ export async function loadPipelineSessionCommand(
         }
 
         if (!session.session || !sessionDir) {
-            statusBarMessenger.showError('Failed to parse pipeline session');
+            vscode.window.showErrorMessage('Failed to parse pipeline session');
             return;
         }
 
@@ -434,7 +434,6 @@ export async function loadPipelineSessionCommand(
         statusBarMessenger.show(`Loaded: ${sessionName}`, 'folder-library');
         logger.info(`Pipeline session loaded successfully: ${sessionName}`);
     } catch (error) {
-        logger.error('Failed to load pipeline session', error);
-        statusBarMessenger.showError(`Pipeline session load failed: ${error}`);
+        handleError(error, ErrorContext.PIPELINE_SESSION_LOAD);
     }
 }

--- a/src/commands/state-commands.ts
+++ b/src/commands/state-commands.ts
@@ -8,6 +8,7 @@
 import * as vscode from 'vscode';
 import { ExtensionState } from '../state/extension-state';
 import { statusBarMessenger } from '../utils/status-bar-messenger';
+import { handleError, ErrorContext } from '../utils/error-handler';
 
 /**
  * Register state management commands
@@ -79,7 +80,7 @@ async function refreshReadsFromBackend(state: ExtensionState): Promise<void> {
 
         statusBarMessenger.show('Refreshed', 'refresh');
     } catch (error) {
-        statusBarMessenger.showError(`Refresh failed: ${error}`);
+        handleError(error, ErrorContext.STATE_REFRESH);
     } finally {
         state.readsViewPane?.setLoading(false);
     }
@@ -189,6 +190,6 @@ async function debugModificationsPanel(state: ExtensionState): Promise<void> {
             statusBarMessenger.show('Mods panel visible', 'check');
         }
     } catch (error) {
-        statusBarMessenger.showError(`Debug failed: ${error}`);
+        handleError(error, ErrorContext.STATE_DEBUG);
     }
 }

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -24,6 +24,15 @@ export enum ErrorContext {
     STATE_CLEAR = 'clearing extension state',
     MOTIF_SEARCH = 'searching for motif matches',
     MOTIF_PLOT = 'generating motif aggregate plot',
+    SESSION_SAVE = 'saving session',
+    SESSION_RESTORE = 'restoring session',
+    SESSION_EXPORT = 'exporting session',
+    SESSION_IMPORT = 'importing session',
+    SESSION_CLEAR = 'clearing session',
+    DEMO_LOAD = 'loading demo session',
+    PIPELINE_SESSION_LOAD = 'loading pipeline session',
+    STATE_REFRESH = 'refreshing session state',
+    STATE_DEBUG = 'inspecting session state',
 }
 
 /**


### PR DESCRIPTION
Consolidates the session/state command error handling per the audit (#189).

## Problem
`session-commands.ts` and `state-commands.ts` reported failures via `statusBarMessenger.showError(\`… ${error}\`)`, which **never logged** to the Output channel and showed errors as easy-to-miss status-bar text. A failed save/restore/export/import/refresh/clear left no trace for debugging.

## Change
Route those catch-blocks through `handleError(error, ErrorContext.X)` — which logs to the Squiggy output channel and shows a notification with a "Show Logs" action, consistent with how `file-commands`/`plot-commands` already handle errors. Added the matching `ErrorContext` values (`SESSION_SAVE`, `SESSION_RESTORE`, …, `STATE_REFRESH`, `STATE_DEBUG`) and removed two now-redundant `logger.error` calls. `statusBarMessenger` is retained for success/transient notices.

Updated the corresponding error-path tests to assert the error is now surfaced (they previously asserted it was *not*).

## Scope
Focused on the genuinely-broken no-log paths (session + state commands). `plot-commands.ts` uses ~20 raw `showErrorMessage` calls that *do* surface errors (just not via `ErrorContext`); converting those is lower-value/higher-churn and is left as a follow-up.

## Verification
- tsc clean · Jest 517 passed / 7 skipped · eslint + prettier clean

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)