### PR TITLE
refactor: extract shared genomic-coordinate helpers for plot strategies (#188)

### DIFF
--- a/squiggy/plot_strategies/base.py
+++ b/squiggy/plot_strategies/base.py
@@ -216,6 +216,119 @@ class PlotStrategy(ABC):
 
         return signal, seq_to_sig_map
 
+    def _build_genomic_ref_positions(self, aligned_read) -> list[float]:
+        """
+        Map each signal sample of an aligned read to a genomic position.
+
+        Walks the read's aligned bases and emits one reference position per
+        signal sample. Soft-clipped or inserted bases (genomic_pos is None)
+        reuse the previous mapped position, or the first mapped position when
+        they occur at the very start of the read.
+
+        Args:
+            aligned_read: Aligned read with ``.bases`` (each having
+                ``genomic_pos``, ``signal_start``, ``signal_end``).
+
+        Returns:
+            List of genomic positions, one per signal sample. Empty if the read
+            has no genomic positions at all (e.g. fully unmapped/soft-clipped).
+        """
+        # Find the first valid genomic position (skip soft-clipped start)
+        first_genomic_pos = None
+        for base in aligned_read.bases:
+            if base.genomic_pos is not None:
+                first_genomic_pos = base.genomic_pos
+                break
+
+        ref_positions: list[float] = []
+        for base in aligned_read.bases:
+            num_samples = base.signal_end - base.signal_start
+            if base.genomic_pos is not None:
+                # Mapped base - use genomic position
+                ref_positions.extend([base.genomic_pos] * num_samples)
+            elif first_genomic_pos is not None:
+                # Insertion or soft-clip - reuse the previous (or first) position
+                if ref_positions:
+                    ref_positions.extend([ref_positions[-1]] * num_samples)
+                else:
+                    ref_positions.extend([first_genomic_pos] * num_samples)
+
+        return ref_positions
+
+    def _collapse_to_genomic_positions(
+        self,
+        ref_positions: list[float] | np.ndarray,
+        signal_values: np.ndarray,
+        downsample: int,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Align signal values to genomic positions, collapsing repeats by mean.
+
+        Downsamples/pads ``ref_positions`` to match ``signal_values``, then
+        collapses consecutive samples sharing a genomic position into their
+        mean (so Bokeh draws a point per position instead of a vertical line),
+        inserting NaN breaks at deletions (a genomic-position jump > 1).
+
+        The caller must ensure ``ref_positions`` is non-empty.
+
+        Args:
+            ref_positions: One genomic position per signal sample (from
+                :meth:`_build_genomic_ref_positions`).
+            signal_values: Signal/offset values to collapse, parallel to the
+                un-collapsed signal (e.g. processed signal or y-offset signal).
+            downsample: Downsampling factor already applied to ``signal_values``.
+
+        Returns:
+            Tuple of (collapsed_positions, collapsed_values) as numpy arrays.
+        """
+        # Convert to float to allow NaN insertion later (for deletions)
+        ref_positions = np.array(ref_positions, dtype=float)
+
+        # Apply the same downsampling stride that was applied to the signal
+        if downsample > 1 and len(ref_positions) > len(signal_values):
+            ref_positions = ref_positions[::downsample]
+
+        # Ensure lengths match after downsampling
+        if len(ref_positions) < len(signal_values):
+            ref_positions = np.pad(
+                ref_positions,
+                (0, len(signal_values) - len(ref_positions)),
+                mode="edge",
+            )
+        elif len(ref_positions) > len(signal_values):
+            ref_positions = ref_positions[: len(signal_values)]
+
+        # Collapse repeated positions (mean of accumulated signal values)
+        unique_positions: list[float] = []
+        unique_signals: list[float] = []
+
+        current_pos = ref_positions[0]
+        current_signals = [signal_values[0]]
+
+        for i in range(1, len(ref_positions)):
+            if ref_positions[i] == current_pos:
+                # Same position - accumulate signal values
+                current_signals.append(signal_values[i])
+            else:
+                # New position - save mean of accumulated signals
+                unique_positions.append(current_pos)
+                unique_signals.append(np.mean(current_signals))
+
+                # Check for deletion (position jump > 1) - break line with NaN
+                if ref_positions[i] - current_pos > 1:
+                    unique_positions.append(np.nan)
+                    unique_signals.append(np.nan)
+
+                # Start new position
+                current_pos = ref_positions[i]
+                current_signals = [signal_values[i]]
+
+        # Don't forget the last position
+        unique_positions.append(current_pos)
+        unique_signals.append(np.mean(current_signals))
+
+        return np.array(unique_positions), np.array(unique_signals)
+
     def _validate_read_tuples(self, reads: list) -> None:
         """
         Validate list of read tuples

--- a/squiggy/plot_strategies/overlay.py
+++ b/squiggy/plot_strategies/overlay.py
@@ -157,31 +157,9 @@ class OverlayPlotStrategy(PlotStrategy):
                 # Use BAM alignment positions (reference-anchored coordinates)
                 aligned_read = aligned_reads[idx]
 
-                # Build x-coordinates from genomic positions
-                # Handle soft-clipping and insertions by using position from aligned bases
-
-                # First, find the first valid genomic position (skip soft-clipped start)
-                first_genomic_pos = None
-                for base in aligned_read.bases:
-                    if base.genomic_pos is not None:
-                        first_genomic_pos = base.genomic_pos
-                        break
-
-                # Build position array using signal sample indices mapped to genomic coordinates
-                ref_positions = []
-                for base in aligned_read.bases:
-                    num_samples = base.signal_end - base.signal_start
-                    if base.genomic_pos is not None:
-                        # Mapped base - use genomic position
-                        ref_positions.extend([base.genomic_pos] * num_samples)
-                    elif first_genomic_pos is not None:
-                        # Insertion or soft-clip - use interpolated position
-                        # Use the genomic position of the previous mapped base
-                        if ref_positions:
-                            ref_positions.extend([ref_positions[-1]] * num_samples)
-                        else:
-                            # Soft-clipped at start - use first genomic position
-                            ref_positions.extend([first_genomic_pos] * num_samples)
+                # Build x-coordinates from genomic positions (shared helper).
+                # Handles soft-clipping and insertions.
+                ref_positions = self._build_genomic_ref_positions(aligned_read)
 
                 # Check if we got any genomic positions at all
                 if not ref_positions:
@@ -202,62 +180,10 @@ class OverlayPlotStrategy(PlotStrategy):
                     skipped_reads.append(read_id)
                     continue
 
-                # Apply same downsampling to genomic positions as was applied to signal
-                # The signal was downsampled, so we need to downsample positions to match
-                # Convert to float to allow NaN insertion later (for deletions)
-                ref_positions = np.array(ref_positions, dtype=float)
-
-                # Downsample ref_positions if signal was downsampled
-                if downsample > 1 and len(ref_positions) > len(processed_signal):
-                    # Apply same downsampling stride to genomic positions
-                    ref_positions = ref_positions[::downsample]
-
-                # Ensure lengths match after downsampling
-                if len(ref_positions) < len(processed_signal):
-                    # Pad with last position if needed
-                    ref_positions = np.pad(
-                        ref_positions,
-                        (0, len(processed_signal) - len(ref_positions)),
-                        mode="edge",
-                    )
-                elif len(ref_positions) > len(processed_signal):
-                    # Truncate if still too long
-                    ref_positions = ref_positions[: len(processed_signal)]
-
-                # For reference-anchored plots, we need to handle repeated positions
-                # When multiple samples map to same genomic position, Bokeh draws vertical lines
-                # Solution: Keep only unique positions (take mean of signal for each position)
-                unique_positions = []
-                unique_signals = []
-
-                current_pos = ref_positions[0]
-                current_signals = [processed_signal[0]]
-
-                for i in range(1, len(ref_positions)):
-                    if ref_positions[i] == current_pos:
-                        # Same position - accumulate signal values
-                        current_signals.append(processed_signal[i])
-                    else:
-                        # New position - save mean of accumulated signals
-                        unique_positions.append(current_pos)
-                        unique_signals.append(np.mean(current_signals))
-
-                        # Check for deletion (position jump > 1)
-                        if ref_positions[i] - current_pos > 1:
-                            # Insert NaN to break line at deletion
-                            unique_positions.append(np.nan)
-                            unique_signals.append(np.nan)
-
-                        # Start new position
-                        current_pos = ref_positions[i]
-                        current_signals = [processed_signal[i]]
-
-                # Don't forget the last position
-                unique_positions.append(current_pos)
-                unique_signals.append(np.mean(current_signals))
-
-                ref_positions = np.array(unique_positions)
-                processed_signal = np.array(unique_signals)
+                # Collapse repeated positions (mean per position, NaN at deletions)
+                ref_positions, processed_signal = self._collapse_to_genomic_positions(
+                    ref_positions, processed_signal, downsample
+                )
 
                 x = ref_positions
             else:

--- a/squiggy/plot_strategies/single_read.py
+++ b/squiggy/plot_strategies/single_read.py
@@ -390,83 +390,17 @@ class SingleReadPlotStrategy(PlotStrategy):
         Returns:
             Tuple of (positions, collapsed_signal, label)
         """
-        # Build genomic position array from aligned read
-        ref_positions = []
-
-        # Find first valid genomic position
-        first_genomic_pos = None
-        for base in aligned_read.bases:
-            if base.genomic_pos is not None:
-                first_genomic_pos = base.genomic_pos
-                break
-
-        # Build position array
-        for base in aligned_read.bases:
-            num_samples = base.signal_end - base.signal_start
-            if base.genomic_pos is not None:
-                # Mapped base - use genomic position
-                ref_positions.extend([base.genomic_pos] * num_samples)
-            elif first_genomic_pos is not None:
-                # Insertion or soft-clip - use last valid position
-                if ref_positions:
-                    ref_positions.extend([ref_positions[-1]] * num_samples)
-                else:
-                    ref_positions.extend([first_genomic_pos] * num_samples)
+        # Build genomic position array from aligned read (shared helper)
+        ref_positions = self._build_genomic_ref_positions(aligned_read)
 
         if not ref_positions:
             # Fallback to sample indices if no genomic positions available
             return np.arange(len(signal)), signal, "Sample"
 
-        # Convert to float for NaN support
-        ref_positions = np.array(ref_positions, dtype=float)
-
-        # Downsample if needed
-        if downsample > 1 and len(ref_positions) > len(signal):
-            ref_positions = ref_positions[::downsample]
-
-        # Ensure lengths match
-        if len(ref_positions) < len(signal):
-            ref_positions = np.pad(
-                ref_positions,
-                (0, len(signal) - len(ref_positions)),
-                mode="edge",
-            )
-        elif len(ref_positions) > len(signal):
-            ref_positions = ref_positions[: len(signal)]
-
         # Collapse repeated positions (average signal at each unique position)
-        unique_positions = []
-        unique_signals = []
-
-        current_pos = ref_positions[0]
-        current_signals = [signal[0]]
-
-        for i in range(1, len(ref_positions)):
-            if ref_positions[i] == current_pos:
-                # Same position - accumulate signal values
-                current_signals.append(signal[i])
-            else:
-                # New position - save mean of accumulated signals
-                unique_positions.append(current_pos)
-                unique_signals.append(np.mean(current_signals))
-
-                # Check for deletion (position jump > 1)
-                if ref_positions[i] - current_pos > 1:
-                    # Insert NaN to break line at deletion
-                    unique_positions.append(np.nan)
-                    unique_signals.append(np.nan)
-
-                # Start new position
-                current_pos = ref_positions[i]
-                current_signals = [signal[i]]
-
-        # Don't forget the last position
-        unique_positions.append(current_pos)
-        unique_signals.append(np.mean(current_signals))
-
-        # Convert to arrays
-        collapsed_positions = np.array(unique_positions)
-        collapsed_signal = np.array(unique_signals)
+        collapsed_positions, collapsed_signal = self._collapse_to_genomic_positions(
+            ref_positions, signal, downsample
+        )
 
         return collapsed_positions, collapsed_signal, "Reference Position"
 

--- a/squiggy/plot_strategies/stacked.py
+++ b/squiggy/plot_strategies/stacked.py
@@ -5,6 +5,8 @@ This module implements the Strategy Pattern for stacking multiple nanopore reads
 vertically with offsets.
 """
 
+import logging
+
 import numpy as np
 from bokeh.embed import file_html
 from bokeh.models import ColumnDataSource, HoverTool
@@ -13,6 +15,8 @@ from bokeh.resources import CDN
 from ..constants import MULTI_READ_COLORS, NormalizationMethod, Theme
 from ..rendering import ThemeManager
 from .base import PlotStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class StackedPlotStrategy(PlotStrategy):
@@ -151,108 +155,33 @@ class StackedPlotStrategy(PlotStrategy):
                 # Use BAM alignment positions (reference-anchored coordinates)
                 aligned_read = aligned_reads[idx]
 
-                # Build x-coordinates from genomic positions
-                # Handle soft-clipping and insertions by using position from aligned bases
-
-                # First, find the first valid genomic position (skip soft-clipped start)
-                first_genomic_pos = None
-                for base in aligned_read.bases:
-                    if base.genomic_pos is not None:
-                        first_genomic_pos = base.genomic_pos
-                        break
-
-                # Build position array using signal sample indices mapped to genomic coordinates
-                ref_positions = []
-                for base in aligned_read.bases:
-                    num_samples = base.signal_end - base.signal_start
-                    if base.genomic_pos is not None:
-                        # Mapped base - use genomic position
-                        ref_positions.extend([base.genomic_pos] * num_samples)
-                    elif first_genomic_pos is not None:
-                        # Insertion or soft-clip - use interpolated position
-                        # Use the genomic position of the previous mapped base
-                        if ref_positions:
-                            ref_positions.extend([ref_positions[-1]] * num_samples)
-                        else:
-                            # Soft-clipped at start - use first genomic position
-                            ref_positions.extend([first_genomic_pos] * num_samples)
+                # Build x-coordinates from genomic positions (shared helper).
+                # Handles soft-clipping and insertions.
+                ref_positions = self._build_genomic_ref_positions(aligned_read)
 
                 # Check if we got any genomic positions at all
                 if not ref_positions:
                     # Skip unmapped/unaligned reads in sequence space mode
                     # This can happen if: read is unmapped, all bases are insertions, or soft-clipped
-                    print(
-                        f"Warning: Skipping read {read_id} - no genomic positions available"
+                    debug_info = (
+                        f"Skipping read {read_id} - no genomic positions available. "
                     )
-                    print(
-                        f"  Read has {len(aligned_read.bases)} bases, chromosome: {aligned_read.chromosome}"
-                    )
+                    debug_info += f"Read has {len(aligned_read.bases)} bases, chromosome: {aligned_read.chromosome}"
                     if aligned_read.bases:
                         first_bases_genomic = [
                             b.genomic_pos for b in aligned_read.bases[:5]
                         ]
-                        print(
-                            f"  First 5 bases genomic positions: {first_bases_genomic}"
+                        debug_info += (
+                            f". First 5 bases genomic positions: {first_bases_genomic}"
                         )
+                    logger.warning(debug_info)
                     skipped_reads.append(read_id)
                     continue
 
-                # Apply same downsampling to genomic positions as was applied to signal
-                # The signal was downsampled, so we need to downsample positions to match
-                # Convert to float to allow NaN insertion later (for deletions)
-                ref_positions = np.array(ref_positions, dtype=float)
-
-                # Downsample ref_positions if signal was downsampled
-                if downsample > 1 and len(ref_positions) > len(signal):
-                    # Apply same downsampling stride to genomic positions
-                    ref_positions = ref_positions[::downsample]
-
-                # Ensure lengths match after downsampling
-                if len(ref_positions) < len(signal):
-                    # Pad with last position if needed
-                    ref_positions = np.pad(
-                        ref_positions,
-                        (0, len(signal) - len(ref_positions)),
-                        mode="edge",
-                    )
-                elif len(ref_positions) > len(signal):
-                    # Truncate if still too long
-                    ref_positions = ref_positions[: len(signal)]
-
-                # For reference-anchored plots, we need to handle repeated positions
-                # When multiple samples map to same genomic position, Bokeh draws vertical lines
-                # Solution: Keep only unique positions (take mean of signal for each position)
-                unique_positions = []
-                unique_signals = []
-
-                current_pos = ref_positions[0]
-                current_signals = [y_offset[0]]
-
-                for i in range(1, len(ref_positions)):
-                    if ref_positions[i] == current_pos:
-                        # Same position - accumulate signal values
-                        current_signals.append(y_offset[i])
-                    else:
-                        # New position - save mean of accumulated signals
-                        unique_positions.append(current_pos)
-                        unique_signals.append(np.mean(current_signals))
-
-                        # Check for deletion (position jump > 1)
-                        if ref_positions[i] - current_pos > 1:
-                            # Insert NaN to break line at deletion
-                            unique_positions.append(np.nan)
-                            unique_signals.append(np.nan)
-
-                        # Start new position
-                        current_pos = ref_positions[i]
-                        current_signals = [y_offset[i]]
-
-                # Don't forget the last position
-                unique_positions.append(current_pos)
-                unique_signals.append(np.mean(current_signals))
-
-                ref_positions = np.array(unique_positions)
-                y_offset = np.array(unique_signals)
+                # Collapse repeated positions (mean per position, NaN at deletions)
+                ref_positions, y_offset = self._collapse_to_genomic_positions(
+                    ref_positions, y_offset, downsample
+                )
 
                 x = ref_positions
             else:

--- a/tests/test_plot_coordinates.py
+++ b/tests/test_plot_coordinates.py
@@ -1,0 +1,99 @@
+"""Tests for the shared genomic-coordinate helpers on PlotStrategy (Issue #188)
+
+These helpers were extracted from near-identical inline blocks in the
+single_read / overlay / stacked strategies. The tests pin the behavior so the
+shared implementation stays equivalent to the originals.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from squiggy.constants import Theme
+from squiggy.plot_strategies.base import PlotStrategy
+
+
+class _DummyStrategy(PlotStrategy):
+    """Minimal concrete strategy so the protected helpers can be exercised."""
+
+    def create_plot(self, data, options):
+        return "", None
+
+    def validate_data(self, data):
+        return None
+
+
+def _base(genomic_pos, signal_start, signal_end):
+    return SimpleNamespace(
+        genomic_pos=genomic_pos, signal_start=signal_start, signal_end=signal_end
+    )
+
+
+def _read(bases):
+    return SimpleNamespace(bases=bases, chromosome="chr1")
+
+
+def _strategy():
+    return _DummyStrategy(Theme.LIGHT)
+
+
+class TestBuildGenomicRefPositions:
+    def test_basic_mapping(self):
+        read = _read([_base(100, 0, 2), _base(101, 2, 4)])
+        assert _strategy()._build_genomic_ref_positions(read) == [100, 100, 101, 101]
+
+    def test_start_soft_clip_reuses_first_position(self):
+        # First base unmapped (soft-clip): reuse the first mapped genomic pos
+        read = _read([_base(None, 0, 2), _base(100, 2, 4)])
+        assert _strategy()._build_genomic_ref_positions(read) == [100, 100, 100, 100]
+
+    def test_insertion_reuses_previous_position(self):
+        read = _read([_base(100, 0, 2), _base(None, 2, 3), _base(102, 3, 5)])
+        assert _strategy()._build_genomic_ref_positions(read) == [
+            100,
+            100,
+            100,
+            102,
+            102,
+        ]
+
+    def test_no_genomic_positions_returns_empty(self):
+        read = _read([_base(None, 0, 2), _base(None, 2, 4)])
+        assert _strategy()._build_genomic_ref_positions(read) == []
+
+
+class TestCollapseToGenomicPositions:
+    def test_collapses_repeats_by_mean(self):
+        positions, values = _strategy()._collapse_to_genomic_positions(
+            [100, 100, 101, 101], np.array([1.0, 3.0, 5.0, 7.0]), downsample=1
+        )
+        assert list(positions) == [100, 101]
+        assert list(values) == [2.0, 6.0]
+
+    def test_inserts_nan_at_deletion(self):
+        positions, values = _strategy()._collapse_to_genomic_positions(
+            [100, 100, 102], np.array([1.0, 3.0, 5.0]), downsample=1
+        )
+        assert positions[0] == 100
+        assert np.isnan(positions[1])  # NaN break at the deletion gap
+        assert positions[2] == 102
+        assert values[0] == 2.0
+        assert np.isnan(values[1])
+        assert values[2] == 5.0
+
+    def test_downsamples_positions_to_match_signal(self):
+        positions, values = _strategy()._collapse_to_genomic_positions(
+            [100, 100, 101, 101, 102, 102],
+            np.array([1.0, 2.0, 3.0]),
+            downsample=2,
+        )
+        assert list(positions) == [100, 101, 102]
+        assert list(values) == [1.0, 2.0, 3.0]
+
+    def test_pads_positions_to_match_signal(self):
+        positions, values = _strategy()._collapse_to_genomic_positions(
+            [100, 100], np.array([1.0, 2.0, 3.0]), downsample=1
+        )
+        # Padded with the edge position, then collapsed to one point
+        assert list(positions) == [100]
+        assert list(values) == [2.0]


### PR DESCRIPTION
Deduplicates the genomic-coordinate building across the plot strategies (#188).

## Problem
`single_read`, `overlay`, and `stacked` each carried a ~100-line, near-identical copy of the same algorithm: map signal samples → genomic positions (handling soft-clips/insertions), downsample/pad to the signal length, then collapse repeated positions by mean with NaN breaks at deletions. The only real difference was the signal variable (`signal` / `processed_signal` / `y_offset` — all the same length).

## Change
Extracted two helpers onto `PlotStrategy`:
- `_build_genomic_ref_positions(aligned_read)` → list of per-sample positions
- `_collapse_to_genomic_positions(ref_positions, signal_values, downsample)` → `(positions, values)`

and call them from all three strategies. Each keeps its own empty-case handling (single_read falls back to sample indices; overlay/stacked skip the read). Behavior-preserving — removes ~270 lines of duplication and is the same surface that produced the aggregate-track mapping bug (#184). Also switched stacked's skip warnings from `print()` to `logger` (kernel console hygiene).

## Tests
Adds unit tests for both helpers — basic mapping, start soft-clip, insertion, deletion NaN breaks, downsample, pad — coverage the inline copies never had. The existing strategy tests (175) still pass unchanged.

## Verification
- ruff check + format clean · pytest 825 passed / 2 skipped (+8 new)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)