### PR TITLE
refactor: single source of truth for samples in ExtensionState (#187)

### DIFF
--- a/src/state/__tests__/extension-state.test.ts
+++ b/src/state/__tests__/extension-state.test.ts
@@ -132,4 +132,92 @@ describe('ExtensionState', () => {
             expect(state.modificationsProvider).toBeUndefined();
         });
     });
+
+    describe('multi-sample management (single source of truth, #187)', () => {
+        const sample = (name: string, overrides = {}) => ({
+            sampleId: `sample:${name}`,
+            displayName: name,
+            pod5Path: `/data/${name}.pod5`,
+            bamPath: `/data/${name}.bam`,
+            readCount: 100,
+            hasBam: true,
+            hasFasta: false,
+            isLoaded: true,
+            ...overrides,
+        });
+
+        it('adds and looks up a sample by id and by displayName', () => {
+            state.addSample(sample('WT'));
+
+            expect(state.getSample('sample:WT')?.displayName).toBe('WT');
+            expect(state.getSample('WT')?.pod5Path).toBe('/data/WT.pod5');
+            expect(state.getSample('missing')).toBeUndefined();
+        });
+
+        it('returns all sample displayNames in insertion order', () => {
+            state.addSample(sample('WT'));
+            state.addSample(sample('KO'));
+            expect(state.getAllSampleNames()).toEqual(['WT', 'KO']);
+        });
+
+        it('exposes samples through the unified loadedItems registry', () => {
+            state.addSample(sample('WT'));
+            // The sample is a single item in the unified registry, not a second store
+            const items = state.getLoadedItems().filter((i) => i.type === 'sample');
+            expect(items).toHaveLength(1);
+            expect(items[0].id).toBe('sample:WT');
+            expect(state.loadedSamples.get('sample:WT')?.hasBam).toBe(true);
+        });
+
+        it('merges addSample onto a prior addLoadedItem without losing fields', () => {
+            // Caller pattern: addLoadedItem (with file metadata) then addSample
+            state.addLoadedItem({
+                id: 'sample:WT',
+                type: 'sample',
+                sampleName: 'WT',
+                pod5Path: '/data/WT.pod5',
+                readCount: 100,
+                hasAlignments: true,
+                hasReference: false,
+                hasMods: false,
+                hasEvents: false,
+                fileSize: 1234,
+                fileSizeFormatted: '1.2 KB',
+            });
+            state.addSample(sample('WT', { references: [{ name: 'chr1', readCount: 50 }] }));
+
+            const item = state.getLoadedItem('sample:WT');
+            expect(item?.fileSize).toBe(1234); // preserved from addLoadedItem
+            expect(item?.references).toEqual([{ name: 'chr1', readCount: 50 }]); // from addSample
+            expect(state.getLoadedItems().filter((i) => i.type === 'sample')).toHaveLength(1);
+        });
+
+        it('removes a sample by id or by displayName', () => {
+            state.addSample(sample('WT'));
+            state.addSample(sample('KO'));
+
+            state.removeSample('WT'); // by displayName
+            expect(state.getAllSampleNames()).toEqual(['KO']);
+
+            state.removeSample('sample:KO'); // by id
+            expect(state.getAllSampleNames()).toEqual([]);
+        });
+
+        it('does not surface standalone pod5 items as samples', () => {
+            state.addLoadedItem({
+                id: 'pod5:/data/x.pod5',
+                type: 'pod5',
+                pod5Path: '/data/x.pod5',
+                readCount: 10,
+                hasAlignments: false,
+                hasReference: false,
+                hasMods: false,
+                hasEvents: false,
+                fileSize: 0,
+                fileSizeFormatted: '',
+            });
+            expect(state.getAllSampleNames()).toEqual([]);
+            expect(state.getSample('pod5:/data/x.pod5')).toBeUndefined();
+        });
+    });
 });

--- a/src/state/extension-state.ts
+++ b/src/state/extension-state.ts
@@ -104,8 +104,10 @@ export class ExtensionState {
         totalReads: number;
     };
 
-    // Multi-sample state
-    private _loadedSamples: Map<string, SampleInfo> = new Map();
+    // Multi-sample state.
+    // Samples are stored in the unified _loadedItems registry (Issue #187);
+    // the SampleInfo API below is a derived view over the sample-type items, so
+    // there is a single source of truth instead of two hand-synced maps.
     private _selectedSamplesForComparison: string[] = [];
     private _samplesForVisualization: Set<string> = new Set(); // Samples selected for plotting
     private _sessionFastaPath: string | null = null; // Session-level FASTA for all comparisons
@@ -555,22 +557,59 @@ squiggy.close_fasta()
     }
 
     // ========== Multi-Sample Management ==========
+    //
+    // Samples live in the unified _loadedItems registry (type === 'sample').
+    // The methods below present the legacy SampleInfo view over those items so
+    // existing callers are unchanged, while there is only one backing store.
+
+    /**
+     * Map a sample-type LoadedItem to the SampleInfo view.
+     */
+    private _itemToSampleInfo(item: LoadedItem): SampleInfo {
+        return {
+            sampleId: item.id,
+            displayName: item.sampleName ?? item.id,
+            pod5Path: item.pod5Path,
+            bamPath: item.bamPath,
+            fastaPath: item.fastaPath,
+            readCount: item.readCount,
+            hasBam: item.hasAlignments,
+            hasFasta: item.hasReference,
+            hasMods: item.hasMods,
+            hasEvents: item.hasEvents,
+            hasPrimers: item.hasPrimers,
+            references: item.references,
+            isLoaded: item.isLoaded ?? false,
+            metadata: item.metadata,
+        };
+    }
+
+    /**
+     * Iterate the sample-type items in insertion order.
+     */
+    private _sampleItems(): LoadedItem[] {
+        return Array.from(this._loadedItems.values()).filter((i) => i.type === 'sample');
+    }
 
     get loadedSamples(): Map<string, SampleInfo> {
-        return this._loadedSamples;
+        const map = new Map<string, SampleInfo>();
+        for (const item of this._sampleItems()) {
+            map.set(item.id, this._itemToSampleInfo(item));
+        }
+        return map;
     }
 
     getSample(nameOrId: string): SampleInfo | undefined {
-        // First try direct lookup by sampleId
-        const bySampleId = this._loadedSamples.get(nameOrId);
-        if (bySampleId) {
-            return bySampleId;
+        // Direct lookup by sampleId (== item id)
+        const byId = this._loadedItems.get(nameOrId);
+        if (byId && byId.type === 'sample') {
+            return this._itemToSampleInfo(byId);
         }
 
-        // Fall back to search by displayName
-        for (const sample of this._loadedSamples.values()) {
-            if (sample.displayName === nameOrId) {
-                return sample;
+        // Fall back to search by displayName (sampleName)
+        for (const item of this._sampleItems()) {
+            if (item.sampleName === nameOrId) {
+                return this._itemToSampleInfo(item);
             }
         }
 
@@ -578,27 +617,54 @@ squiggy.close_fasta()
     }
 
     addSample(sample: SampleInfo): void {
-        // Use sampleId as the key to preserve insertion order during renames
-        // displayName can be edited in Sample Manager without moving the sample in the list
-        this._loadedSamples.set(sample.sampleId, sample);
+        // Merge the sample's fields into the unified registry, preserving any
+        // LoadedItem-only fields (fileSize, isDeferred, …) already set by a
+        // prior addLoadedItem() call for the same id. Keyed by sampleId so a
+        // displayName rename does not move the item in the list.
+        const existing = this._loadedItems.get(sample.sampleId);
+        const merged: LoadedItem = {
+            // Defaults for LoadedItem-only fields when no prior item exists
+            fileSize: 0,
+            fileSizeFormatted: '',
+            ...existing,
+            // Sample-derived fields (authoritative)
+            id: sample.sampleId,
+            type: 'sample',
+            sampleName: sample.displayName,
+            pod5Path: sample.pod5Path,
+            bamPath: sample.bamPath,
+            fastaPath: sample.fastaPath,
+            readCount: sample.readCount,
+            hasAlignments: sample.hasBam,
+            hasReference: sample.hasFasta,
+            hasMods: sample.hasMods ?? existing?.hasMods ?? false,
+            hasEvents: sample.hasEvents ?? existing?.hasEvents ?? false,
+            hasPrimers: sample.hasPrimers ?? existing?.hasPrimers,
+            references: sample.references ?? existing?.references,
+            isLoaded: sample.isLoaded,
+            metadata: sample.metadata ?? existing?.metadata,
+        };
+        // Does not fire onLoadedItemsChanged (matches the previous addSample,
+        // which was paired with an addLoadedItem call by callers).
+        this._loadedItems.set(merged.id, merged);
     }
 
     removeSample(name: string): void {
         // Also clean up deferred session data
         this._deferredSessionData.delete(name);
 
-        // Support removal by displayName (for backward compatibility) or by sampleId
-        // First try direct lookup by sampleId
-        if (this._loadedSamples.has(name)) {
-            this._loadedSamples.delete(name);
+        // Remove by sampleId (== item id) ...
+        const byId = this._loadedItems.get(name);
+        if (byId && byId.type === 'sample') {
+            this._loadedItems.delete(name);
             return;
         }
 
-        // Fall back to search by displayName
-        for (const [sampleId, sample] of this._loadedSamples) {
-            if (sample.displayName === name) {
-                this._deferredSessionData.delete(sample.displayName);
-                this._loadedSamples.delete(sampleId);
+        // ... or by displayName (sampleName)
+        for (const item of this._sampleItems()) {
+            if (item.sampleName === name) {
+                this._deferredSessionData.delete(item.sampleName);
+                this._loadedItems.delete(item.id);
                 return;
             }
         }
@@ -606,7 +672,7 @@ squiggy.close_fasta()
 
     getAllSampleNames(): string[] {
         // Return displayNames (user-facing names) in insertion order
-        return Array.from(this._loadedSamples.values()).map((sample) => sample.displayName);
+        return this._sampleItems().map((item) => item.sampleName ?? item.id);
     }
 
     get selectedSamplesForComparison(): string[] {
@@ -734,15 +800,6 @@ squiggy.close_fasta()
                     }
                 }
             }
-        } else if (this._loadedSamples.size > 0) {
-            // Fall back to legacy multi-sample mode
-            for (const [sampleName, sampleInfo] of this._loadedSamples.entries()) {
-                samples[sampleName] = {
-                    pod5Paths: [sampleInfo.pod5Path],
-                    bamPath: sampleInfo.bamPath,
-                    fastaPath: sampleInfo.fastaPath,
-                };
-            }
         } else {
             // Fall back to legacy single-file mode
             if (this._currentPod5File) {
@@ -866,7 +923,7 @@ squiggy.close_fasta()
                 extensionUri,
             });
 
-            // Also create a skeleton SampleInfo entry in legacy state
+            // Merge skeleton sample fields onto the unified item created above
             const skeletonSampleInfo: SampleInfo = {
                 sampleId: itemId,
                 displayName: sampleName,
@@ -882,7 +939,7 @@ squiggy.close_fasta()
                     sourceType: 'manual',
                 },
             };
-            this._loadedSamples.set(sampleName, skeletonSampleInfo);
+            this.addSample(skeletonSampleInfo);
         }
 
         // Update samples panel to show skeletons immediately
@@ -1313,22 +1370,9 @@ squiggy.close_fasta()
 
         // ========== Update State with Final Data ==========
 
-        // Update SampleInfo in legacy state
-        const sampleInfo = this._loadedSamples.get(sampleName);
-        if (sampleInfo) {
-            sampleInfo.pod5Path = resolvedPod5Paths[0];
-            sampleInfo.bamPath = resolvedBamPath;
-            sampleInfo.fastaPath = resolvedFastaPath;
-            sampleInfo.readCount = numReads;
-            sampleInfo.hasBam = !!resolvedBamPath;
-            sampleInfo.hasFasta = !!resolvedFastaPath;
-            sampleInfo.hasMods = bamResult?.hasModifications ?? false;
-            sampleInfo.hasEvents = bamResult?.hasEventAlignment ?? false;
-            sampleInfo.hasPrimers = bamResult?.hasPrimers ?? false;
-            sampleInfo.isLoaded = true;
-        }
-
-        // Update LoadedItem with final data and mark as complete
+        // Update the unified item with final data and mark as complete.
+        // (The SampleInfo view derives from this item, so a single update keeps
+        // the sample API and the registry in sync.)
         this.updateLoadedItemData(itemId, {
             pod5Path: resolvedPod5Paths[0],
             bamPath: resolvedBamPath,
@@ -1340,6 +1384,7 @@ squiggy.close_fasta()
             hasEvents: bamResult?.hasEventAlignment ?? false,
             hasPrimers: bamResult?.hasPrimers ?? false,
             isRna: bamResult?.isRna ?? false,
+            isLoaded: true,
             isLoading: false, // Mark as complete
             isDeferred: false, // No longer deferred
             loadingMessage: undefined,

--- a/src/types/loaded-item.ts
+++ b/src/types/loaded-item.ts
@@ -125,4 +125,30 @@ export interface LoadedItem {
      * (deferred loading - session paths loaded but kernel work deferred until user clicks Load)
      */
     isDeferred?: boolean;
+
+    // ========== Sample fields (type === 'sample') ==========
+    // These let a SampleInfo be derived losslessly from a LoadedItem, so the
+    // unified registry is the single source of truth (Issue #187). They are
+    // unset/ignored for standalone pod5-type items.
+
+    /**
+     * References this sample aligns to (from BAM), with per-reference read counts
+     */
+    references?: { name: string; readCount: number; length?: number }[];
+
+    /**
+     * Whether the sample's files have been loaded into the kernel
+     */
+    isLoaded?: boolean;
+
+    /**
+     * Extensible sample metadata (display color, source type, tags, …)
+     */
+    metadata?: {
+        autoDetected?: boolean;
+        displayColor?: string;
+        sourceType?: 'manual' | 'tsv';
+        tsvGroup?: string;
+        tags?: string[];
+    };
 }


### PR DESCRIPTION
Consolidates the dual sample stores in `ExtensionState` (#187) — the largest item from the audit.

## Problem
Sample data lived in two hand-synced maps: legacy `_loadedSamples: Map<string, SampleInfo>` and unified `_loadedItems: Map<string, LoadedItem>`. Callers updated both in lockstep (`addSample` + `addLoadedItem`, `removeSample` + `removeLoadedItem`); any path that touched one but not the other silently desynced the UI, and `toSessionState` carried a 3-way fallback cascade to cope.

## Approach
Make `_loadedItems` the **single backing store** and present the `SampleInfo` API as a derived view:
- Extend `LoadedItem` with the `SampleInfo`-only fields (`references`, `isLoaded`, `metadata`) so a `SampleInfo` maps losslessly to/from a `LoadedItem`.
- Reimplement `loadedSamples` / `getSample` / `addSample` / `removeSample` / `getAllSampleNames` over `_loadedItems`. `addSample` **merges** onto any existing item for the same id, preserving `LoadedItem`-only fields (`fileSize`, …).
- Drop `_loadedSamples`, the dead legacy-multi branch in `toSessionState`, and the redundant `SampleInfo` mutation in `restoreSampleWithProgress`.

The key property: the existing caller pattern (`addLoadedItem` then `addSample`, keyed by the same `sample:<name>` id) is preserved and now hits one store idempotently — so **external callers need no changes** and desync is structurally impossible.

## Verification
- tsc clean · full Jest suite **529 passed / 7 skipped** (incl. the file/plot/samples-panel tests that drive the sample API) · eslint + prettier clean.
- Adds direct `ExtensionState` tests: add/lookup by id & displayName, insertion order, the `addLoadedItem`+`addSample` merge (no field loss), removal by id/name, and pod5-vs-sample item separation.

## Out of scope (noted follow-up)
The parallel **selection** silos (`_selectedSamplesForComparison` / `_samplesForVisualization` vs `_selectedItemIds` / `_itemsForComparison`) are selection state, not the duplicated data store, and carry higher risk to unify (they need a `sampleName`↔`itemId` mapping rewired through the panels, which have thin test coverage). Left for a focused follow-up so this data-consolidation lands cleanly and verifiably.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)