### PR TITLE
Complete multi-track aggregate plot + fix plotting/UX wiring gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,6 +282,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "squiggy.debugModificationsPanel",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "squiggy.refreshReads",

--- a/squiggy/plot_strategies/aggregate_comparison.py
+++ b/squiggy/plot_strategies/aggregate_comparison.py
@@ -108,13 +108,17 @@ class AggregateComparisonStrategy(PlotStrategy):
         if "enabled_metrics" not in data:
             raise ValueError("Missing required key: 'enabled_metrics'")
 
-    def _create_signal_track(self, samples: list[dict], reference_name: str):
+    def _create_signal_track(
+        self, samples: list[dict], reference_name: str, title: str | None = None
+    ):
         """
         Create signal statistics comparison track
 
         Args:
             samples: List of sample data dicts with 'signal_stats'
             reference_name: Reference name for plot title
+            title: Optional explicit title (overrides the default comparison title;
+                used by the multi-track layout to label per-sample groups)
 
         Returns:
             Bokeh figure or None if no signal data
@@ -125,7 +129,7 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         # Create themed figure
         p = self.theme_manager.create_figure(
-            title=f"Signal Statistics Comparison - {reference_name}",
+            title=title or f"Signal Statistics Comparison - {reference_name}",
             x_label="Reference Position (bp)",
             y_label="Normalized Signal",
         )
@@ -206,13 +210,16 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         return p
 
-    def _create_dwell_track(self, samples: list[dict], reference_name: str):
+    def _create_dwell_track(
+        self, samples: list[dict], reference_name: str, title: str | None = None
+    ):
         """
         Create dwell time statistics comparison track
 
         Args:
             samples: List of sample data dicts with 'dwell_stats'
             reference_name: Reference name for plot title
+            title: Optional explicit title (overrides the default comparison title)
 
         Returns:
             Bokeh figure or None if no dwell data
@@ -223,7 +230,7 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         # Create themed figure
         p = self.theme_manager.create_figure(
-            title=f"Dwell Time Statistics Comparison - {reference_name}",
+            title=title or f"Dwell Time Statistics Comparison - {reference_name}",
             x_label="Reference Position (bp)",
             y_label="Dwell Time (samples)",
         )
@@ -304,13 +311,16 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         return p
 
-    def _create_quality_track(self, samples: list[dict], reference_name: str):
+    def _create_quality_track(
+        self, samples: list[dict], reference_name: str, title: str | None = None
+    ):
         """
         Create quality statistics comparison track
 
         Args:
             samples: List of sample data dicts with 'quality_stats'
             reference_name: Reference name for plot title
+            title: Optional explicit title (overrides the default comparison title)
 
         Returns:
             Bokeh figure or None if no quality data
@@ -321,7 +331,7 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         # Create themed figure
         p = self.theme_manager.create_figure(
-            title=f"Quality Statistics Comparison - {reference_name}",
+            title=title or f"Quality Statistics Comparison - {reference_name}",
             x_label="Reference Position (bp)",
             y_label="Quality Score",
         )
@@ -436,13 +446,90 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         return tracks
 
-    def _create_coverage_track(self, samples: list[dict], reference_name: str):
+    def _create_multitrack_layout(
+        self,
+        samples: list[dict],
+        reference_name: str,
+        enabled_metrics: list[str],
+        show_pileup: bool,
+        rna_mode: bool,
+    ) -> list:
+        """
+        Build a detailed per-sample layout: one complete group of tracks per sample
+
+        Unlike the overlay layout (which superimposes every sample on shared axes),
+        this gives each sample its own signal / pileup / dwell / quality / coverage
+        block, stacked vertically and grouped together. This makes it easier to read
+        each sample's full profile at the cost of direct visual overlap.
+
+        The per-sample track builders are reused by passing a single-element sample
+        list, then the figure title is prefixed with the sample name so the group
+        boundaries are obvious in the stacked layout.
+
+        Args:
+            samples: List of sample data dicts
+            reference_name: Reference name for plot titles
+            enabled_metrics: Metrics to render (signal, dwell_time, quality)
+            show_pileup: Whether to include a base-call pileup track per sample
+            rna_mode: Display U instead of T in pileup tracks for RNA sequences
+
+        Returns:
+            Ordered list of Bokeh figures (sample groups concatenated)
+        """
+        tracks = []
+
+        for sample in samples:
+            name = sample["name"]
+            group = []
+
+            if "signal" in enabled_metrics:
+                signal_track = self._create_signal_track(
+                    [sample], reference_name, title=f"{name} — Signal"
+                )
+                if signal_track:
+                    group.append(signal_track)
+
+            if show_pileup:
+                pileup_stats = sample.get("pileup_stats")
+                if pileup_stats and len(pileup_stats.get("positions", [])) > 0:
+                    group.extend(
+                        self._create_pileup_tracks([sample], rna_mode=rna_mode)
+                    )
+
+            if "dwell_time" in enabled_metrics:
+                dwell_track = self._create_dwell_track(
+                    [sample], reference_name, title=f"{name} — Dwell Time"
+                )
+                if dwell_track:
+                    group.append(dwell_track)
+
+            if "quality" in enabled_metrics:
+                quality_track = self._create_quality_track(
+                    [sample], reference_name, title=f"{name} — Quality"
+                )
+                if quality_track:
+                    group.append(quality_track)
+
+            coverage_track = self._create_coverage_track(
+                [sample], reference_name, title=f"{name} — Coverage"
+            )
+            if coverage_track:
+                group.append(coverage_track)
+
+            tracks.extend(group)
+
+        return tracks
+
+    def _create_coverage_track(
+        self, samples: list[dict], reference_name: str, title: str | None = None
+    ):
         """
         Create coverage comparison track
 
         Args:
             samples: List of sample data dicts with coverage data
             reference_name: Reference name for plot title
+            title: Optional explicit title (overrides the default comparison title)
 
         Returns:
             Bokeh figure or None if no coverage data
@@ -453,7 +540,7 @@ class AggregateComparisonStrategy(PlotStrategy):
 
         # Create themed figure (smaller height for coverage)
         p = self.theme_manager.create_figure(
-            title=f"Coverage Comparison - {reference_name}",
+            title=title or f"Coverage Comparison - {reference_name}",
             x_label="Reference Position (bp)",
             y_label="Read Count",
             height=350,  # Slightly shorter than default
@@ -553,37 +640,49 @@ class AggregateComparisonStrategy(PlotStrategy):
         enabled_metrics = data.get(
             "enabled_metrics", ["signal", "dwell_time", "quality"]
         )
+        # 'overlay' (default): superimpose all samples on shared axes.
+        # 'multi-track': one complete, labelled track group per sample.
+        view_style = data.get("view_style", "overlay")
+        show_pileup = bool(data.get("show_pileup"))
+        rna_mode = data.get("rna_mode", False)
 
-        # Create tracks based on enabled metrics
-        tracks = []
-
-        if "signal" in enabled_metrics:
-            signal_track = self._create_signal_track(samples, reference_name)
-            if signal_track:
-                tracks.append(signal_track)
-
-        # Per-sample base-call pileup tracks (the most important comparison panel)
-        if data.get("show_pileup"):
-            tracks.extend(
-                self._create_pileup_tracks(
-                    samples, rna_mode=data.get("rna_mode", False)
-                )
+        if view_style == "multi-track":
+            tracks = self._create_multitrack_layout(
+                samples,
+                reference_name,
+                enabled_metrics,
+                show_pileup,
+                rna_mode,
             )
+        else:
+            # Overlay layout: each track superimposes every sample
+            tracks = []
 
-        if "dwell_time" in enabled_metrics:
-            dwell_track = self._create_dwell_track(samples, reference_name)
-            if dwell_track:
-                tracks.append(dwell_track)
+            if "signal" in enabled_metrics:
+                signal_track = self._create_signal_track(samples, reference_name)
+                if signal_track:
+                    tracks.append(signal_track)
 
-        if "quality" in enabled_metrics:
-            quality_track = self._create_quality_track(samples, reference_name)
-            if quality_track:
-                tracks.append(quality_track)
+            # Per-sample base-call pileup tracks (the most important comparison panel)
+            if show_pileup:
+                tracks.extend(
+                    self._create_pileup_tracks(samples, rna_mode=rna_mode)
+                )
 
-        # Always try to add coverage track if data available
-        coverage_track = self._create_coverage_track(samples, reference_name)
-        if coverage_track:
-            tracks.append(coverage_track)
+            if "dwell_time" in enabled_metrics:
+                dwell_track = self._create_dwell_track(samples, reference_name)
+                if dwell_track:
+                    tracks.append(dwell_track)
+
+            if "quality" in enabled_metrics:
+                quality_track = self._create_quality_track(samples, reference_name)
+                if quality_track:
+                    tracks.append(quality_track)
+
+            # Always try to add coverage track if data available
+            coverage_track = self._create_coverage_track(samples, reference_name)
+            if coverage_track:
+                tracks.append(coverage_track)
 
         if not tracks:
             raise ValueError("No tracks could be created with the provided data")

--- a/squiggy/plot_strategies/aggregate_comparison.py
+++ b/squiggy/plot_strategies/aggregate_comparison.py
@@ -665,9 +665,7 @@ class AggregateComparisonStrategy(PlotStrategy):
 
             # Per-sample base-call pileup tracks (the most important comparison panel)
             if show_pileup:
-                tracks.extend(
-                    self._create_pileup_tracks(samples, rna_mode=rna_mode)
-                )
+                tracks.extend(self._create_pileup_tracks(samples, rna_mode=rna_mode))
 
             if "dwell_time" in enabled_metrics:
                 dwell_track = self._create_dwell_track(samples, reference_name)

--- a/squiggy/plotting.py
+++ b/squiggy/plotting.py
@@ -1741,6 +1741,7 @@ def plot_aggregate_comparison(
     trim_primers: bool = True,
     show_pileup: bool = True,
     rna_mode: bool = False,
+    view_style: str = "overlay",
 ) -> str:
     """
     Generate aggregate comparison plot for multiple samples
@@ -1766,6 +1767,9 @@ def plot_aggregate_comparison(
         trim_primers: Trim primer/adapter regions using FASTA body bounds (default True)
         show_pileup: Add one base-call pileup track per sample (default True)
         rna_mode: Display U instead of T in pileup tracks for RNA sequences (default False)
+        view_style: Layout style for the comparison. 'overlay' (default) superimposes
+                    all samples on shared axes; 'multi-track' renders one complete,
+                    labelled track group per sample, stacked vertically.
 
     Returns:
         Bokeh HTML string with aggregate comparison visualization
@@ -1960,6 +1964,7 @@ def plot_aggregate_comparison(
         "primer_trim_bounds": primer_trim_bounds,
         "show_pileup": show_pileup,
         "rna_mode": rna_mode,
+        "view_style": view_style,
     }
 
     options = {"normalization": norm_method}

--- a/src/backend/squiggy-kernel-manager.ts
+++ b/src/backend/squiggy-kernel-manager.ts
@@ -781,7 +781,29 @@ assert hasattr(squiggy, 'plot_read'), "squiggy.plot_read not found"
         logger.warning(`Dedicated kernel session ended: ${JSON.stringify(exit)}`);
         this.session = undefined;
         this.setState(SquiggyKernelState.Error);
-        // TODO: Implement auto-restart logic
+        this.promptRestart();
+    }
+
+    /**
+     * Notify the user that the Squiggy kernel stopped and offer a one-click
+     * restart, instead of leaving the extension silently broken until they
+     * discover the restart command themselves. Skipped during disposal (the
+     * extension is shutting down, so a prompt would be noise).
+     */
+    private promptRestart(): void {
+        if (this.isDisposed) {
+            return;
+        }
+        vscode.window
+            .showErrorMessage(
+                'The Squiggy kernel stopped. Plots and data loading are unavailable.',
+                'Restart Kernel'
+            )
+            .then((choice) => {
+                if (choice === 'Restart Kernel') {
+                    vscode.commands.executeCommand('squiggy.restartBackgroundKernel');
+                }
+            });
     }
 
     /**

--- a/src/backend/squiggy-runtime-api.ts
+++ b/src/backend/squiggy-runtime-api.ts
@@ -1090,10 +1090,7 @@ if '_result' in globals():
             // from a legitimately empty sample (the caller would show a misleading
             // "No reads found" message). The caller (loadReadsForSample) surfaces
             // this to the user via showErrorMessage.
-            logger.error(
-                `Failed to get read IDs and references for sample '${sampleName}'`,
-                error
-            );
+            logger.error(`Failed to get read IDs and references for sample '${sampleName}'`, error);
             throw error;
         }
     }

--- a/src/backend/squiggy-runtime-api.ts
+++ b/src/backend/squiggy-runtime-api.ts
@@ -390,12 +390,13 @@ squiggy.load_bam(${toPyStr(filePath)})
             const readIdsJson = JSON.stringify(readIds);
             const enabledModTypesJson = JSON.stringify(enabledModTypes);
 
-            // Build sample name parameter if in multi-sample mode
-            const sampleNameParam = sampleName ? `, sample_name='${sampleName}'` : '';
+            // Build sample name parameter if in multi-sample mode.
+            // Use toPyStr so names containing quotes/backslashes are escaped safely.
+            const sampleNameParam = sampleName ? `, sample_name=${toPyStr(sampleName)}` : '';
 
             // Build coordinate space parameter if specified
             const coordinateSpaceParam = coordinateSpace
-                ? `, coordinate_space='${coordinateSpace}'`
+                ? `, coordinate_space=${toPyStr(coordinateSpace)}`
                 : '';
 
             // Build the plot function call with proper multi-line formatting
@@ -1084,11 +1085,16 @@ if '_result' in globals():
                 references: data.references || [],
             };
         } catch (error) {
-            logger.warning(
+            // Re-throw rather than returning empty: this is the initial-load path,
+            // and swallowing here makes a genuine kernel/IO failure indistinguishable
+            // from a legitimately empty sample (the caller would show a misleading
+            // "No reads found" message). The caller (loadReadsForSample) surfaces
+            // this to the user via showErrorMessage.
+            logger.error(
                 `Failed to get read IDs and references for sample '${sampleName}'`,
                 error
             );
-            return { readIds: [], references: [] };
+            throw error;
         }
     }
 
@@ -1425,7 +1431,8 @@ squiggy.plot_delta_comparison(
         sampleColors?: Record<string, string>,
         trimPrimers: boolean = true,
         showPileup: boolean = true,
-        rnaMode: boolean = false
+        rnaMode: boolean = false,
+        viewStyle: 'overlay' | 'multi-track' = 'overlay'
     ): Promise<void> {
         // Validate input
         if (!sampleNames || sampleNames.length < 2) {
@@ -1465,7 +1472,8 @@ squiggy.plot_aggregate_comparison(
     theme='${theme}',
     trim_primers=${trimPrimers ? 'True' : 'False'},
     show_pileup=${showPileup ? 'True' : 'False'},
-    rna_mode=${rnaMode ? 'True' : 'False'}${maxReadsParam}${sampleColorsParam}
+    rna_mode=${rnaMode ? 'True' : 'False'},
+    view_style=${toPyStr(viewStyle)}${maxReadsParam}${sampleColorsParam}
 )
 `;
 

--- a/src/commands/__tests__/plot-commands.test.ts
+++ b/src/commands/__tests__/plot-commands.test.ts
@@ -108,6 +108,7 @@ describe('Plot Commands', () => {
             const expectedCommands = [
                 'squiggy.plotRead',
                 'squiggy.plotAggregate',
+                'squiggy.plotMotifAggregate',
                 'squiggy.plotMotifAggregateAll',
                 'squiggy.plotSignalOverlayComparison',
                 'squiggy.plotDeltaComparison',
@@ -124,8 +125,8 @@ describe('Plot Commands', () => {
         it('should add all command disposables to context', () => {
             registerCommands();
 
-            // Verify registerCommand was called 9 times (once per command)
-            expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(9);
+            // Verify registerCommand was called 10 times (once per command)
+            expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(10);
         });
     });
 

--- a/src/commands/file-commands.ts
+++ b/src/commands/file-commands.ts
@@ -902,20 +902,23 @@ async function loadSampleForComparison(
 
     const pod5Path = pod5Uris[0].fsPath;
 
-    // Optionally select BAM file
+    // Optionally select BAM file. Cancelling skips it (the POD5 + name already
+    // entered are kept) rather than aborting the whole flow.
     const bamUris = await vscode.window.showOpenDialog({
         canSelectMany: false,
         filters: { 'BAM Files': ['bam'] },
-        title: 'Select BAM file (optional)',
+        title: 'Select BAM file — or Cancel to skip (optional)',
+        openLabel: 'Select BAM',
     });
 
     const bamPath = bamUris?.[0]?.fsPath;
 
-    // Optionally select FASTA file
+    // Optionally select FASTA file. Cancelling skips it.
     const fastaUris = await vscode.window.showOpenDialog({
         canSelectMany: false,
         filters: { 'FASTA Files': ['fa', 'fasta', 'fna'] },
-        title: 'Select FASTA file (optional)',
+        title: 'Select FASTA file — or Cancel to skip (optional)',
+        openLabel: 'Select FASTA',
     });
 
     const fastaPath = fastaUris?.[0]?.fsPath;

--- a/src/commands/plot-commands.ts
+++ b/src/commands/plot-commands.ts
@@ -52,6 +52,11 @@ export function registerPlotCommands(
                     return;
                 }
 
+                // Remember this plot so option/theme/filter changes can replay it
+                state.lastPlotAction = {
+                    command: 'squiggy.plotRead',
+                    args: [readIdOrItem, coordinateSpace],
+                };
                 await plotReads(readIds, state, coordinateSpace);
             }
         )
@@ -99,7 +104,28 @@ export function registerPlotCommands(
                 return;
             }
 
+            state.lastPlotAction = {
+                command: 'squiggy.plotAggregate',
+                args: [referenceName],
+            };
             await plotAggregate(referenceName, state);
+        })
+    );
+
+    // Plot motif aggregate (command-palette entry point). A motif aggregate
+    // plot needs a motif sequence and flank sizes, which are entered in the
+    // Motif Explorer panel — so reveal that panel where the actual plotting
+    // controls live, rather than failing silently.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('squiggy.plotMotifAggregate', async () => {
+            if (!state.currentFastaFile) {
+                vscode.window.showWarningMessage(
+                    'Motif aggregate plots require a FASTA reference. Open a FASTA file first, ' +
+                        'then enter a motif in the Motif Explorer panel.'
+                );
+            }
+            // Reveal the Motif Explorer where the user enters a motif and plots.
+            await vscode.commands.executeCommand('squiggyMotifSearch.focus');
         })
     );
 
@@ -141,6 +167,10 @@ export function registerPlotCommands(
                     return;
                 }
 
+                state.lastPlotAction = {
+                    command: 'squiggy.plotMotifAggregateAll',
+                    args: [params],
+                };
                 await plotMotifAggregateAll(params, state);
             }
         )
@@ -174,6 +204,10 @@ export function registerPlotCommands(
                     return;
                 }
 
+                state.lastPlotAction = {
+                    command: 'squiggy.plotSignalOverlayComparison',
+                    args: [sampleNames, maxReads],
+                };
                 await plotSignalOverlayComparison(sampleNames, state, maxReads);
             }
         )
@@ -228,6 +262,10 @@ export function registerPlotCommands(
                     return;
                 }
 
+                state.lastPlotAction = {
+                    command: 'squiggy.plotDeltaComparison',
+                    args: [sampleNames, referenceName, maxReads],
+                };
                 await plotDeltaComparison(sampleNames, referenceName, state, maxReads);
             }
         )
@@ -242,6 +280,7 @@ export function registerPlotCommands(
                 reference: string;
                 metrics: string[];
                 maxReads?: number;
+                viewStyle?: 'overlay' | 'multi-track';
             }) => {
                 // If no params provided, validate and prompt user
                 if (!params) {
@@ -275,6 +314,10 @@ export function registerPlotCommands(
                     return;
                 }
 
+                state.lastPlotAction = {
+                    command: 'squiggy.plotAggregateComparison',
+                    args: [params],
+                };
                 await plotAggregateComparison(params, state);
             }
         )
@@ -301,6 +344,10 @@ export function registerPlotCommands(
                 const maxReadsPerSample = maxReads || 10;
                 const coordSpace = coordinateSpace || 'signal';
 
+                state.lastPlotAction = {
+                    command: 'squiggy.plotMultiReadOverlay',
+                    args: [sampleNames, maxReadsPerSample, coordSpace],
+                };
                 await plotMultiReadOverlay(sampleNames, maxReadsPerSample, coordSpace, state);
             }
         )
@@ -327,6 +374,10 @@ export function registerPlotCommands(
                 const maxReadsPerSample = maxReads || 5;
                 const coordSpace = coordinateSpace || 'signal';
 
+                state.lastPlotAction = {
+                    command: 'squiggy.plotMultiReadStacked',
+                    args: [sampleNames, maxReadsPerSample, coordSpace],
+                };
                 await plotMultiReadStacked(sampleNames, maxReadsPerSample, coordSpace, state);
             }
         )
@@ -352,6 +403,10 @@ export function registerPlotCommands(
                 }
 
                 const maxReadsPerSample = maxReads || 10;
+                state.lastPlotAction = {
+                    command: 'squiggy.plotReferenceOverlay',
+                    args: [sampleNames, maxReadsPerSample, reference],
+                };
                 await plotReferenceOverlay(sampleNames, maxReadsPerSample, reference, state);
             }
         )
@@ -452,24 +507,28 @@ async function plotAggregate(referenceName: string, state: ExtensionState): Prom
                 enabledModTypes: [],
             };
 
+            // Honor the user's Plot Options panel selections instead of
+            // hardcoding the track set (the panel is the single source of truth).
             await api.generateAggregatePlot(
                 referenceName,
                 maxReads,
                 normalization,
                 theme,
-                true, // showModifications
+                options.showModifications,
                 modFilters.minProbability,
                 modFilters.enabledModTypes,
-                true, // showPileup
-                true, // showDwellTime
-                true, // showSignal
-                true, // showQuality
-                false, // showCoverage (off by default)
-                true, // clipXAxisToAlignment
-                true, // transformCoordinates
-                undefined, // Pass current sample for multi-sample mode
+                options.showPileup,
+                options.showDwellTime,
+                options.showSignal,
+                options.showQuality,
+                false, // showCoverage: not exposed in the Plot Options getter; off by default
+                options.clipXAxisToAlignment,
+                options.transformCoordinates,
+                state.selectedReadExplorerSample ?? undefined, // current sample for multi-sample mode
                 modFilters.minFrequency,
-                modFilters.minModifiedReads
+                modFilters.minModifiedReads,
+                options.rnaMode,
+                options.trimPrimers ?? true
             );
         },
         ErrorContext.PLOT_GENERATE,
@@ -732,6 +791,7 @@ async function plotAggregateComparison(
         reference: string;
         metrics: string[];
         maxReads?: number;
+        viewStyle?: 'overlay' | 'multi-track';
     },
     state: ExtensionState
 ): Promise<void> {
@@ -806,7 +866,8 @@ async function plotAggregateComparison(
                 Object.keys(sampleColors).length > 0 ? sampleColors : undefined,
                 options?.trimPrimers ?? true,
                 showPileup,
-                rnaMode
+                rnaMode,
+                params.viewStyle ?? 'overlay'
             );
         },
         ErrorContext.PLOT_GENERATE,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -420,33 +420,26 @@ async function registerAllPanelsAndCommands(context: vscode.ExtensionContext): P
     // Set initial context for modifications panel (hidden by default)
     vscode.commands.executeCommand('setContext', 'squiggy.hasModifications', false);
 
-    // Listen for plot option changes and refresh current plot
+    // Listen for plot option changes and refresh current plot. replayLastPlot()
+    // re-runs the exact last plot command (any mode), and that command re-reads
+    // the live options/theme/filters, so the refreshed plot reflects the change.
     context.subscriptions.push(
         plotOptionsProvider.onDidChangeOptions(() => {
-            if (state.currentPlotReadIds && state.currentPlotReadIds.length > 0) {
-                // Re-plot with new options
-                vscode.commands.executeCommand('squiggy.plotRead', state.currentPlotReadIds[0]);
-            }
+            void state.replayLastPlot();
         })
     );
 
     // Listen for modification filter changes and refresh current plot
     context.subscriptions.push(
         modificationsProvider.onDidChangeFilters(() => {
-            if (state.currentPlotReadIds && state.currentPlotReadIds.length > 0) {
-                // Re-plot with new modification filters
-                vscode.commands.executeCommand('squiggy.plotRead', state.currentPlotReadIds[0]);
-            }
+            void state.replayLastPlot();
         })
     );
 
     // Listen for theme changes and refresh current plot
     context.subscriptions.push(
         vscode.window.onDidChangeActiveColorTheme(() => {
-            if (state.currentPlotReadIds && state.currentPlotReadIds.length > 0) {
-                // Re-plot with new theme
-                vscode.commands.executeCommand('squiggy.plotRead', state.currentPlotReadIds[0]);
-            }
+            void state.replayLastPlot();
         })
     );
 
@@ -645,38 +638,35 @@ async function registerAllPanelsAndCommands(context: vscode.ExtensionContext): P
 
                     statusBarMessenger.show(`Aggregate: ${options.reference}`, 'graph');
                 } else if (options.sampleNames.length > 1) {
-                    // Multi-sample aggregate plot
-                    if (options.viewStyle === 'overlay') {
-                        // Use aggregate comparison (overlays mean signals)
-                        // Convert boolean flags to metrics array
-                        const metrics: string[] = [];
-                        if (options.showSignal) {
-                            metrics.push('signal');
-                        }
-                        if (options.showDwellTime) {
-                            metrics.push('dwell_time');
-                        }
-                        if (options.showQuality) {
-                            metrics.push('quality');
-                        }
-
-                        await vscode.commands.executeCommand('squiggy.plotAggregateComparison', {
-                            sampleNames: options.sampleNames,
-                            reference: options.reference,
-                            metrics: metrics,
-                            maxReads: options.maxReads,
-                        });
-
-                        statusBarMessenger.show(
-                            `Comparison: ${options.sampleNames.length} samples`,
-                            'graph'
-                        );
-                    } else {
-                        // Multi-track mode (separate detailed tracks per sample)
-                        vscode.window.showWarningMessage(
-                            'Multi-track aggregate view not yet implemented. Use overlay mode for now.'
-                        );
+                    // Multi-sample aggregate plot. Both 'overlay' and 'multi-track'
+                    // use the aggregate-comparison strategy; the layout is selected
+                    // in Python via the view_style parameter.
+                    // Convert boolean flags to metrics array
+                    const metrics: string[] = [];
+                    if (options.showSignal) {
+                        metrics.push('signal');
                     }
+                    if (options.showDwellTime) {
+                        metrics.push('dwell_time');
+                    }
+                    if (options.showQuality) {
+                        metrics.push('quality');
+                    }
+
+                    await vscode.commands.executeCommand('squiggy.plotAggregateComparison', {
+                        sampleNames: options.sampleNames,
+                        reference: options.reference,
+                        metrics: metrics,
+                        maxReads: options.maxReads,
+                        viewStyle: options.viewStyle,
+                    });
+
+                    const styleLabel =
+                        options.viewStyle === 'multi-track' ? 'multi-track' : 'overlay';
+                    statusBarMessenger.show(
+                        `Comparison (${styleLabel}): ${options.sampleNames.length} samples`,
+                        'graph'
+                    );
                 } else {
                     statusBarMessenger.showError('No samples selected');
                 }

--- a/src/state/extension-state.ts
+++ b/src/state/extension-state.ts
@@ -96,6 +96,11 @@ export class ExtensionState {
     private _currentBamFile?: string;
     private _currentFastaFile?: string;
     private _currentPlotReadIds?: string[];
+    // The last plot the user generated, captured as the command + args that
+    // produced it. Used to re-plot when options/theme/mod-filters change. The
+    // commands re-read live options at execution time, so replaying picks up the
+    // new settings automatically.
+    private _lastPlotAction?: { command: string; args: unknown[] };
 
     // Lazy loading context
     private _pod5LoadContext?: {
@@ -212,6 +217,7 @@ export class ExtensionState {
         this._currentBamFile = undefined;
         this._currentFastaFile = undefined;
         this._currentPlotReadIds = undefined;
+        this._lastPlotAction = undefined;
 
         // Reset installation check flags
         this._squiggyInstallChecked = false;
@@ -298,6 +304,27 @@ squiggy.close_fasta()
 
     set currentPlotReadIds(value: string[] | undefined) {
         this._currentPlotReadIds = value;
+    }
+
+    get lastPlotAction(): { command: string; args: unknown[] } | undefined {
+        return this._lastPlotAction;
+    }
+
+    set lastPlotAction(value: { command: string; args: unknown[] } | undefined) {
+        this._lastPlotAction = value;
+    }
+
+    /**
+     * Re-run the most recent plot command (if any). Used by the auto-replot
+     * listeners when plot options, theme, or modification filters change.
+     */
+    async replayLastPlot(): Promise<void> {
+        if (this._lastPlotAction) {
+            await vscode.commands.executeCommand(
+                this._lastPlotAction.command,
+                ...this._lastPlotAction.args
+            );
+        }
     }
 
     get selectedReadExplorerSample(): string | null {

--- a/src/views/__tests__/squiggy-plot-options-panel.test.ts
+++ b/src/views/__tests__/squiggy-plot-options-panel.test.ts
@@ -173,13 +173,17 @@ describe('PlotOptionsViewProvider', () => {
             expect(options.showQuality).toBe(false);
         });
 
-        it('should handle requestReferences message', async () => {
+        it('should handle requestReferences message by pushing references to webview', async () => {
             const messageHandler = mockWebviewView.webview.onDidReceiveMessage.mock.calls[0][0];
 
             await messageHandler({ type: 'requestReferences' });
 
-            // Should fire change event for extension.ts to handle
-            expect(optionsChangeListener).toHaveBeenCalled();
+            // Should push the current reference list back to the webview rather
+            // than firing a change event (which would trigger a re-plot, not a fetch)
+            expect(mockWebviewView.webview.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'updateReferences' })
+            );
+            expect(optionsChangeListener).not.toHaveBeenCalled();
         });
 
         it('should handle generateAggregatePlot message', async () => {

--- a/src/views/components/squiggy-samples-core.tsx
+++ b/src/views/components/squiggy-samples-core.tsx
@@ -26,6 +26,7 @@ interface SamplesState {
     sessionFastaPath: string | null; // Session-level FASTA file path
     editingSampleName: string | null; // Which sample name is being edited
     editInputValue: string; // Current value in edit input
+    nameEditError: string | null; // Inline validation error for the name edit input
     sampleColors: Map<string, string>; // Map of sample names to hex colors
     expandedSamples: Set<string>; // Which samples have their details expanded
     selectedSamplesForVisualization: Set<string>; // Which samples are selected for plotting
@@ -37,6 +38,7 @@ export const SamplesCore: React.FC = () => {
         sessionFastaPath: null,
         editingSampleName: null,
         editInputValue: '',
+        nameEditError: null,
         sampleColors: new Map(),
         expandedSamples: new Set(), // Start with all samples collapsed
         selectedSamplesForVisualization: new Set(), // Start with no samples selected
@@ -144,6 +146,7 @@ export const SamplesCore: React.FC = () => {
                         sessionFastaPath: null,
                         editingSampleName: null,
                         editInputValue: '',
+                        nameEditError: null,
                         sampleColors: new Map(),
                         expandedSamples: new Set(),
                         selectedSamplesForVisualization: new Set(),
@@ -217,12 +220,15 @@ export const SamplesCore: React.FC = () => {
             ...prev,
             editingSampleName: sampleName,
             editInputValue: sampleName,
+            nameEditError: null,
         }));
     };
 
     const handleSaveNameEdit = (oldName: string, newName: string) => {
         if (!newName.trim()) {
-            alert('Sample name cannot be empty');
+            // Inline validation error (renders below the input). A native alert()
+            // would pop a non-themed OS dialog that clashes with the Positron UI.
+            setState((prev) => ({ ...prev, nameEditError: 'Sample name cannot be empty' }));
             return;
         }
 
@@ -232,13 +238,17 @@ export const SamplesCore: React.FC = () => {
                 ...prev,
                 editingSampleName: null,
                 editInputValue: '',
+                nameEditError: null,
             }));
             return;
         }
 
         // Check for duplicate names
         if (state.samples.some((s) => s.name === newName)) {
-            alert('A sample with this name already exists');
+            setState((prev) => ({
+                ...prev,
+                nameEditError: 'A sample with this name already exists',
+            }));
             return;
         }
 
@@ -254,6 +264,7 @@ export const SamplesCore: React.FC = () => {
             ...prev,
             editingSampleName: null,
             editInputValue: '',
+            nameEditError: null,
         }));
     };
 
@@ -262,6 +273,7 @@ export const SamplesCore: React.FC = () => {
             ...prev,
             editingSampleName: null,
             editInputValue: '',
+            nameEditError: null,
         }));
     };
 
@@ -674,11 +686,13 @@ export const SamplesCore: React.FC = () => {
                                         <div
                                             style={{
                                                 display: 'flex',
-                                                gap: '4px',
+                                                flexDirection: 'column',
+                                                gap: '2px',
                                                 flex: 1,
                                             }}
                                             onClick={(e) => e.stopPropagation()}
                                         >
+                                          <div style={{ display: 'flex', gap: '4px' }}>
                                             <input
                                                 ref={editInputRef}
                                                 type="text"
@@ -687,6 +701,7 @@ export const SamplesCore: React.FC = () => {
                                                     setState((prev) => ({
                                                         ...prev,
                                                         editInputValue: e.target.value,
+                                                        nameEditError: null,
                                                     }))
                                                 }
                                                 onKeyDown={(e) => {
@@ -754,6 +769,17 @@ export const SamplesCore: React.FC = () => {
                                             >
                                                 ✕
                                             </button>
+                                          </div>
+                                          {state.nameEditError && (
+                                              <span
+                                                  style={{
+                                                      color: 'var(--vscode-errorForeground)',
+                                                      fontSize: '0.8em',
+                                                  }}
+                                              >
+                                                  {state.nameEditError}
+                                              </span>
+                                          )}
                                         </div>
                                     ) : (
                                         <label

--- a/src/views/components/squiggy-samples-core.tsx
+++ b/src/views/components/squiggy-samples-core.tsx
@@ -692,94 +692,94 @@ export const SamplesCore: React.FC = () => {
                                             }}
                                             onClick={(e) => e.stopPropagation()}
                                         >
-                                          <div style={{ display: 'flex', gap: '4px' }}>
-                                            <input
-                                                ref={editInputRef}
-                                                type="text"
-                                                value={state.editInputValue}
-                                                onChange={(e) =>
-                                                    setState((prev) => ({
-                                                        ...prev,
-                                                        editInputValue: e.target.value,
-                                                        nameEditError: null,
-                                                    }))
-                                                }
-                                                onKeyDown={(e) => {
-                                                    e.stopPropagation();
-                                                    if (e.key === 'Enter') {
+                                            <div style={{ display: 'flex', gap: '4px' }}>
+                                                <input
+                                                    ref={editInputRef}
+                                                    type="text"
+                                                    value={state.editInputValue}
+                                                    onChange={(e) =>
+                                                        setState((prev) => ({
+                                                            ...prev,
+                                                            editInputValue: e.target.value,
+                                                            nameEditError: null,
+                                                        }))
+                                                    }
+                                                    onKeyDown={(e) => {
+                                                        e.stopPropagation();
+                                                        if (e.key === 'Enter') {
+                                                            handleSaveNameEdit(
+                                                                sample.name,
+                                                                state.editInputValue
+                                                            );
+                                                        } else if (e.key === 'Escape') {
+                                                            handleCancelNameEdit();
+                                                        }
+                                                    }}
+                                                    style={{
+                                                        flex: 1,
+                                                        padding: '3px',
+                                                        backgroundColor:
+                                                            'var(--vscode-input-background)',
+                                                        color: 'var(--vscode-input-foreground)',
+                                                        border: '1px solid var(--vscode-input-border)',
+                                                        borderRadius: '2px',
+                                                        fontWeight: 'bold',
+                                                        fontFamily: 'var(--vscode-font-family)',
+                                                        fontSize: '0.95em',
+                                                    }}
+                                                />
+                                                <button
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
                                                         handleSaveNameEdit(
                                                             sample.name,
                                                             state.editInputValue
                                                         );
-                                                    } else if (e.key === 'Escape') {
+                                                    }}
+                                                    style={{
+                                                        padding: '2px 4px',
+                                                        backgroundColor:
+                                                            'var(--vscode-button-background)',
+                                                        color: 'var(--vscode-button-foreground)',
+                                                        border: 'none',
+                                                        borderRadius: '2px',
+                                                        cursor: 'pointer',
+                                                        fontSize: '0.85em',
+                                                        flexShrink: 0,
+                                                    }}
+                                                >
+                                                    ✓
+                                                </button>
+                                                <button
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
                                                         handleCancelNameEdit();
-                                                    }
-                                                }}
-                                                style={{
-                                                    flex: 1,
-                                                    padding: '3px',
-                                                    backgroundColor:
-                                                        'var(--vscode-input-background)',
-                                                    color: 'var(--vscode-input-foreground)',
-                                                    border: '1px solid var(--vscode-input-border)',
-                                                    borderRadius: '2px',
-                                                    fontWeight: 'bold',
-                                                    fontFamily: 'var(--vscode-font-family)',
-                                                    fontSize: '0.95em',
-                                                }}
-                                            />
-                                            <button
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    handleSaveNameEdit(
-                                                        sample.name,
-                                                        state.editInputValue
-                                                    );
-                                                }}
-                                                style={{
-                                                    padding: '2px 4px',
-                                                    backgroundColor:
-                                                        'var(--vscode-button-background)',
-                                                    color: 'var(--vscode-button-foreground)',
-                                                    border: 'none',
-                                                    borderRadius: '2px',
-                                                    cursor: 'pointer',
-                                                    fontSize: '0.85em',
-                                                    flexShrink: 0,
-                                                }}
-                                            >
-                                                ✓
-                                            </button>
-                                            <button
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    handleCancelNameEdit();
-                                                }}
-                                                style={{
-                                                    padding: '2px 4px',
-                                                    backgroundColor:
-                                                        'var(--vscode-errorForeground)',
-                                                    color: 'var(--vscode-editor-background)',
-                                                    border: 'none',
-                                                    borderRadius: '2px',
-                                                    cursor: 'pointer',
-                                                    fontSize: '0.85em',
-                                                    flexShrink: 0,
-                                                }}
-                                            >
-                                                ✕
-                                            </button>
-                                          </div>
-                                          {state.nameEditError && (
-                                              <span
-                                                  style={{
-                                                      color: 'var(--vscode-errorForeground)',
-                                                      fontSize: '0.8em',
-                                                  }}
-                                              >
-                                                  {state.nameEditError}
-                                              </span>
-                                          )}
+                                                    }}
+                                                    style={{
+                                                        padding: '2px 4px',
+                                                        backgroundColor:
+                                                            'var(--vscode-errorForeground)',
+                                                        color: 'var(--vscode-editor-background)',
+                                                        border: 'none',
+                                                        borderRadius: '2px',
+                                                        cursor: 'pointer',
+                                                        fontSize: '0.85em',
+                                                        flexShrink: 0,
+                                                    }}
+                                                >
+                                                    ✕
+                                                </button>
+                                            </div>
+                                            {state.nameEditError && (
+                                                <span
+                                                    style={{
+                                                        color: 'var(--vscode-errorForeground)',
+                                                        fontSize: '0.8em',
+                                                    }}
+                                                >
+                                                    {state.nameEditError}
+                                                </span>
+                                            )}
                                         </div>
                                     ) : (
                                         <label

--- a/src/views/squiggy-plot-options-panel.ts
+++ b/src/views/squiggy-plot-options-panel.ts
@@ -255,8 +255,10 @@ export class PlotOptionsViewProvider extends BaseWebviewProvider {
         }
 
         if (message.type === 'requestReferences') {
-            // Request will be handled by extension.ts which listens to this event
-            this._onDidChangeOptions.fire();
+            // The webview (re)opened and needs the current reference list to
+            // populate its dropdown. Push back what we already have instead of
+            // firing a change event (which would trigger a re-plot, not a fetch).
+            this.updateReferences(this._availableReferences);
         }
 
         if (message.type === 'generateAggregatePlot') {

--- a/src/views/squiggy-samples-panel.ts
+++ b/src/views/squiggy-samples-panel.ts
@@ -580,11 +580,59 @@ export class SamplesPanelProvider extends BaseWebviewProvider {
     }
 
     /**
-     * Prompt user to confirm and customize sample names
+     * Ensure every queued sample has a unique name, suffixing collisions
+     * (_2, _3, ...). Used for the "accept suggested names" paths so a batch
+     * import never fails or silently overwrites on duplicate filenames.
+     */
+    private dedupeSampleNames(
+        items: { pod5Path: string; bamPath?: string; sampleName: string }[],
+        takenNames: string[] = []
+    ): { pod5Path: string; bamPath?: string; sampleName: string }[] {
+        const used = new Set(takenNames);
+        return items.map((item) => {
+            let name = item.sampleName.trim() || path.basename(item.pod5Path);
+            if (used.has(name)) {
+                let n = 2;
+                while (used.has(`${name}_${n}`)) {
+                    n++;
+                }
+                name = `${name}_${n}`;
+            }
+            used.add(name);
+            return { ...item, sampleName: name };
+        });
+    }
+
+    /**
+     * Prompt user to confirm and customize sample names.
+     *
+     * Offers an up-front "use suggested names for all" fast path so a single
+     * Escape doesn't discard the whole batch. If the user names samples
+     * individually and then cancels midway, the already-confirmed names are
+     * kept and the remaining files fall back to their suggested names rather
+     * than dropping the entire import.
      */
     private async confirmSampleNames(
         fileQueue: { pod5Path: string; bamPath?: string; sampleName: string }[]
     ): Promise<{ pod5Path: string; bamPath?: string; sampleName: string }[]> {
+        const USE_SUGGESTED = 'Use suggested names for all';
+        const NAME_INDIVIDUALLY = 'Name each sample individually';
+
+        // For a single file, skip the chooser and go straight to the prompt.
+        if (fileQueue.length > 1) {
+            const choice = await vscode.window.showQuickPick([USE_SUGGESTED, NAME_INDIVIDUALLY], {
+                placeHolder: `Name ${fileQueue.length} samples`,
+            });
+
+            if (choice === undefined) {
+                return []; // Cancelled the whole import at the first prompt
+            }
+
+            if (choice === USE_SUGGESTED) {
+                return this.dedupeSampleNames(fileQueue);
+            }
+        }
+
         const confirmed: { pod5Path: string; bamPath?: string; sampleName: string }[] = [];
 
         for (let i = 0; i < fileQueue.length; i++) {
@@ -611,8 +659,15 @@ export class SamplesPanelProvider extends BaseWebviewProvider {
             });
 
             if (customName === undefined) {
-                // User cancelled
-                return [];
+                // User cancelled mid-batch: keep what's confirmed and accept
+                // suggested names for this and the remaining files rather than
+                // discarding the whole import.
+                const remaining = this.dedupeSampleNames(
+                    fileQueue.slice(i),
+                    confirmed.map((c) => c.sampleName)
+                );
+                confirmed.push(...remaining);
+                return confirmed;
             }
 
             confirmed.push({

--- a/src/views/squiggy-session-panel.ts
+++ b/src/views/squiggy-session-panel.ts
@@ -9,6 +9,7 @@ import { BaseWebviewProvider } from './base-webview-provider';
 import { SessionStateManager } from '../state/session-state-manager';
 import { ExtensionState } from '../state/extension-state';
 import { SessionPanelIncomingMessage, UpdateSessionMessage } from '../types/messages';
+import { logger } from '../utils/logger';
 
 export class SessionPanelProvider extends BaseWebviewProvider {
     public static readonly viewType = 'squiggySessionPanel';
@@ -80,8 +81,10 @@ export class SessionPanelProvider extends BaseWebviewProvider {
 
                 this.postMessage(message);
             })
-            .catch(() => {
-                // Session load failure is non-critical; panel will show default state
+            .catch((err) => {
+                // Session load failure is non-critical; panel will show default
+                // state. Log it so session-restore issues are diagnosable.
+                logger.warning('[SessionPanel] Failed to load saved session:', err);
             });
     }
 }

--- a/tests/test_aggregate_comparison_strategy.py
+++ b/tests/test_aggregate_comparison_strategy.py
@@ -885,3 +885,102 @@ class TestPerSamplePileupTracks:
 
         assert isinstance(html, str)
         assert len(html) > 0
+
+
+class TestMultiTrackLayout:
+    """Tests for the 'multi-track' view style (per-sample track groups)"""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Two samples, all metrics, no pileup data"""
+        positions = np.arange(25)
+        return {
+            "samples": [
+                {
+                    "name": "control",
+                    "signal_stats": {
+                        "positions": positions,
+                        "mean_signal": np.sin(positions / 5),
+                        "std_signal": np.full(25, 0.2),
+                    },
+                    "dwell_stats": {
+                        "positions": positions,
+                        "mean_dwell": np.full(25, 10.0),
+                        "std_dwell": np.full(25, 2.0),
+                    },
+                    "quality_stats": {
+                        "positions": positions,
+                        "mean_quality": np.full(25, 30.0),
+                        "std_quality": np.full(25, 3.0),
+                    },
+                    "coverage": {"positions": positions, "coverage": np.full(25, 25)},
+                },
+                {
+                    "name": "treatment",
+                    "signal_stats": {
+                        "positions": positions,
+                        "mean_signal": np.sin(positions / 5) + 0.5,
+                        "std_signal": np.full(25, 0.3),
+                    },
+                    "dwell_stats": {
+                        "positions": positions,
+                        "mean_dwell": np.full(25, 12.0),
+                        "std_dwell": np.full(25, 2.5),
+                    },
+                    "quality_stats": {
+                        "positions": positions,
+                        "mean_quality": np.full(25, 28.0),
+                        "std_quality": np.full(25, 4.0),
+                    },
+                    "coverage": {"positions": positions, "coverage": np.full(25, 30)},
+                },
+            ],
+            "reference_name": "test_ref:100-125",
+            "enabled_metrics": ["signal", "dwell_time", "quality"],
+            "view_style": "multi-track",
+        }
+
+    def test_multitrack_has_per_sample_track_groups(self, sample_data):
+        """Multi-track renders one full track group per sample.
+
+        2 samples x (signal + dwell + quality + coverage) = 8 tracks, versus
+        4 tracks for the overlay layout of the same data.
+        """
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        _, grid = strategy.create_plot(sample_data, {})
+
+        assert isinstance(grid, GridPlot)
+        assert len(grid.children) == 8
+
+    def test_multitrack_titles_are_prefixed_with_sample_name(self, sample_data):
+        """Each track is labelled with its sample so groups are distinguishable"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        _, grid = strategy.create_plot(sample_data, {})
+
+        titles = [fig.title.text for fig, _row, _col in grid.children]
+        assert "control — Signal" in titles
+        assert "treatment — Signal" in titles
+        assert "control — Coverage" in titles
+        assert "treatment — Coverage" in titles
+
+    def test_multitrack_tracks_share_x_range(self, sample_data):
+        """All multi-track figures are x-linked for synchronized zoom/pan"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        _, grid = strategy.create_plot(sample_data, {})
+
+        figures = [fig for fig, _row, _col in grid.children]
+        first_x_range = figures[0].x_range
+        for fig in figures[1:]:
+            assert fig.x_range is first_x_range
+
+    def test_overlay_remains_default_view_style(self, sample_data):
+        """Without view_style='multi-track', the overlay layout is used (4 tracks)"""
+        strategy = AggregateComparisonStrategy(Theme.LIGHT)
+
+        sample_data.pop("view_style")
+        _, grid = strategy.create_plot(sample_data, {})
+
+        assert len(grid.children) == 4


### PR DESCRIPTION
## Summary

A UX-completeness review surfaced that the **Python plotting backend was already complete**, but several plotting features were **broken or unreachable at the TypeScript/UI layer**. This PR completes the missing wiring (including a genuinely missing multi-track layout), fixes the surrounding UX gaps, and follows up with the remaining non-plotting interaction gaps.

## Plotting features completed

- **Multi-Track aggregate comparison** — the "Multi-Track (Detailed)" view-style option previously showed *"Multi-track aggregate view not yet implemented. Use overlay mode for now."* It now works:
  - New `_create_multitrack_layout()` in `aggregate_comparison.py` renders one complete, sample-labelled track group per sample (signal / pileup / dwell / quality / coverage), stacked and x-linked, instead of overlaying all samples on shared axes. Reuses the existing track-builders via a new `title` param.
  - Threaded a `view_style` parameter through `plot_aggregate_comparison()` → `generateAggregateComparison()` → the `plotAggregateComparison` command → the `extension.ts` handler (stub removed).
- **`squiggy.plotMotifAggregate`** — was declared in `package.json` with no handler (silent no-op in the command palette). Now registered to reveal the Motif Explorer panel where the plot is configured, with a guard if no FASTA is loaded.
- **Aggregate plot honors Plot Options** — `plotAggregate` hardcoded the track flags; it now reads `showPileup`/`showDwellTime`/`showSignal`/`showQuality`/etc. from the panel and passes the selected sample.
- **Auto-replot replays the full last plot action** — changing normalization/theme/mod-filters previously re-plotted only the first read id and was dead for overlay/stacked/aggregate/delta/motif. Added a generic `lastPlotAction` (command + args) on `ExtensionState`; every plot command records itself and the listeners call `replayLastPlot()`, which re-reads live options on replay.
- **`requestReferences`** — fired a re-plot instead of returning references (empty dropdown on panel reopen); now pushes the current reference list back to the webview.

## UX fixes

- Native `alert()` in the samples webview → themed inline validation error.
- Initial reads-load failures were swallowed and misreported as "No reads found" → the load path now re-throws so the existing error toast surfaces (keeps the runtime-api layer UI-free).
- `sample_name` / `coordinate_space` interpolated without escaping → now use `toPyStr()`.
- Hid the `debugModificationsPanel` developer command from the command palette.

## Non-plotting UX gaps (follow-up commit)

- **`loadSampleForComparison`** — optional BAM/FASTA pickers now read "Select … — or Cancel to skip"; cancelling keeps the name + POD5 already entered.
- **Batch sample rename** — a single Escape no longer discards the whole batch. Adds an up-front "use suggested names for all" choice for multi-file drops, and a mid-batch cancel keeps confirmed names and defaults the rest (with collision-suffix dedupe).
- **Kernel session end** — prompts with a one-click "Restart Kernel" action instead of silently leaving the extension broken.
- **Session panel** — logs the previously-swallowed saved-session load failure.

## Testing

- Python: **830 pass** (added 4 multi-track strategy tests), ruff clean, coverage 70.8%.
- TypeScript: `tsc --noEmit` clean, ESLint + Prettier clean, **jest suite passes**, webpack build succeeds.

## Notes

- `squiggy.defaultPlotMode` setting is never read anywhere (only ever written as `'SINGLE'`); left as-is rather than expanding a non-functional enum.
- The `coordinateSpace` Plot Options control remains intentionally derived from `showBaseAnnotations` (a deliberate existing design decision, not changed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)