### PR TITLE
chore: exclude tsconfig.jest.json from the packaged VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ src/**
 eslint.config.mjs
 .prettierrc.json
 tsconfig.json
+tsconfig.jest.json
 jest.config.js
 jest.setup.js
 htmlcov/**


### PR DESCRIPTION
## Summary

The dev-only `tsconfig.jest.json` was being bundled into the packaged extension. This adds it to `.vscodeignore` next to the existing `tsconfig.json` exclusion.

Follow-up to the v0.2.0 packaging cleanup (which removed `.cache/`, `zensical.toml`, and `overrides/`).

## Verification

- `pixi run build` → `Packaged: squiggy-positron-0.2.0.vsix (67 files, 3.57 MB)`
- `unzip -l` of the VSIX shows **0** occurrences of `tsconfig.jest` (was 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)